### PR TITLE
fix: Validate size parameter in Hex.padLeft/padRight

### DIFF
--- a/src/primitives/Hex/errors.js
+++ b/src/primitives/Hex/errors.js
@@ -212,6 +212,34 @@ export class NonIntegerError extends BaseInvalidRangeError {
 	}
 }
 
+/**
+ * Error for invalid size parameter (negative or non-integer)
+ * @extends {BaseInvalidRangeError}
+ */
+export class InvalidSizeError extends BaseInvalidRangeError {
+	/**
+	 * @param {string} [message]
+	 * @param {Object} [options]
+	 * @param {string} [options.code]
+	 * @param {unknown} [options.value]
+	 * @param {string} [options.expected]
+	 * @param {Record<string, unknown>} [options.context]
+	 * @param {string} [options.docsPath]
+	 * @param {Error} [options.cause]
+	 */
+	constructor(message = "Size must be a non-negative integer", options = {}) {
+		super(message, {
+			code: options.code || "HEX_INVALID_SIZE",
+			value: options.value,
+			expected: options.expected || "non-negative integer",
+			context: options.context,
+			docsPath: options.docsPath || "/primitives/hex#error-handling",
+			cause: options.cause,
+		});
+		this.name = "InvalidSizeError";
+	}
+}
+
 // Re-export for backward compatibility
 export const InvalidHexFormatError = InvalidFormatError;
 export const InvalidHexCharacterError = InvalidCharacterError;

--- a/src/primitives/Hex/errors.ts
+++ b/src/primitives/Hex/errors.ts
@@ -184,6 +184,26 @@ export class NonIntegerError extends BaseInvalidRangeError {
 	}
 }
 
+/**
+ * Error for invalid size parameter (negative or non-integer)
+ */
+export class InvalidSizeError extends BaseInvalidRangeError {
+	constructor(
+		message = "Size must be a non-negative integer",
+		options: ErrorOptions = {},
+	) {
+		super(message, {
+			code: options.code || "HEX_INVALID_SIZE",
+			value: options.value,
+			expected: options.expected || "non-negative integer",
+			context: options.context,
+			docsPath: options.docsPath || "/primitives/hex#error-handling",
+			cause: options.cause,
+		});
+		this.name = "InvalidSizeError";
+	}
+}
+
 // Re-export for backward compatibility
 export const InvalidHexFormatError = InvalidFormatError;
 export const InvalidHexCharacterError = InvalidCharacterError;

--- a/src/primitives/Hex/pad.js
+++ b/src/primitives/Hex/pad.js
@@ -1,4 +1,4 @@
-import { SizeExceededError } from "./errors.js";
+import { InvalidSizeError, SizeExceededError } from "./errors.js";
 import { fromBytes } from "./fromBytes.js";
 import { toBytes } from "./toBytes.js";
 
@@ -10,6 +10,7 @@ import { toBytes } from "./toBytes.js";
  * @param {string} hex - Hex string to pad
  * @param {number} targetSize - Target size in bytes
  * @returns {string} Padded hex string
+ * @throws {InvalidSizeError} If targetSize is negative or non-integer
  * @throws {SizeExceededError} If hex exceeds target size
  * @example
  * ```javascript
@@ -20,6 +21,16 @@ import { toBytes } from "./toBytes.js";
  * ```
  */
 export function pad(hex, targetSize) {
+	if (targetSize < 0 || !Number.isInteger(targetSize)) {
+		throw new InvalidSizeError(
+			`Size must be a non-negative integer, got ${targetSize}`,
+			{
+				value: targetSize,
+				expected: "non-negative integer",
+				context: { targetSize },
+			},
+		);
+	}
 	const bytes = toBytes(/** @type {import('./HexType.js').HexType} */ (hex));
 	if (bytes.length > targetSize) {
 		throw new SizeExceededError(

--- a/src/primitives/Hex/pad.test.js
+++ b/src/primitives/Hex/pad.test.js
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { InvalidSizeError, SizeExceededError } from "./errors.js";
+import { pad } from "./pad.js";
+
+describe("Hex.pad", () => {
+	describe("basic padding", () => {
+		it("pads hex to target size on left", () => {
+			const hex = "0x1234";
+			expect(pad(hex, 4)).toBe("0x00001234");
+			expect(pad(hex, 8)).toBe("0x0000000000001234");
+		});
+
+		it("does not pad if already at target size", () => {
+			const hex = "0x1234";
+			expect(pad(hex, 2)).toBe("0x1234");
+		});
+
+		it("throws if hex exceeds target size", () => {
+			const hex = "0x1234abcd";
+			expect(() => pad(hex, 2)).toThrow(SizeExceededError);
+			expect(() => pad(hex, 1)).toThrow(SizeExceededError);
+		});
+
+		it("pads empty hex", () => {
+			const hex = "0x";
+			expect(pad(hex, 2)).toBe("0x0000");
+			expect(pad(hex, 4)).toBe("0x00000000");
+		});
+	});
+
+	describe("invalid size parameter", () => {
+		it("throws for negative size", () => {
+			expect(() => pad("0x1234", -1)).toThrow(InvalidSizeError);
+			expect(() => pad("0x1234", -1)).toThrow(
+				"Size must be a non-negative integer",
+			);
+		});
+
+		it("throws for non-integer size", () => {
+			expect(() => pad("0x1234", 1.5)).toThrow(InvalidSizeError);
+			expect(() => pad("0x1234", 1.5)).toThrow(
+				"Size must be a non-negative integer",
+			);
+		});
+
+		it("allows zero size when hex is empty", () => {
+			expect(pad("0x", 0)).toBe("0x");
+		});
+
+		it("throws for zero size when hex has data", () => {
+			expect(() => pad("0x1234", 0)).toThrow(SizeExceededError);
+		});
+	});
+
+	describe("single byte padding", () => {
+		it("pads single byte to various sizes", () => {
+			const hex = "0xff";
+			expect(pad(hex, 2)).toBe("0x00ff");
+			expect(pad(hex, 4)).toBe("0x000000ff");
+			expect(pad(hex, 8)).toBe("0x00000000000000ff");
+		});
+
+		it("pads zero byte", () => {
+			const hex = "0x00";
+			expect(pad(hex, 2)).toBe("0x0000");
+			expect(pad(hex, 4)).toBe("0x00000000");
+		});
+	});
+
+	describe("common Ethereum sizes", () => {
+		it("pads to Bytes4 size (4 bytes)", () => {
+			const hex = "0x12";
+			const padded = pad(hex, 4);
+			expect(padded.length).toBe(2 + 4 * 2);
+			expect(padded).toBe("0x00000012");
+		});
+
+		it("pads to address size (20 bytes)", () => {
+			const hex = "0x1234";
+			const padded = pad(hex, 20);
+			expect(padded.length).toBe(2 + 20 * 2);
+			expect(padded.startsWith("0x0000")).toBe(true);
+			expect(padded.endsWith("1234")).toBe(true);
+		});
+
+		it("pads to hash size (32 bytes)", () => {
+			const hex = "0xabcd";
+			const padded = pad(hex, 32);
+			expect(padded.length).toBe(2 + 32 * 2);
+			expect(padded.startsWith("0x0000")).toBe(true);
+			expect(padded.endsWith("abcd")).toBe(true);
+		});
+	});
+
+	describe("case handling", () => {
+		it("converts to lowercase when padding", () => {
+			const hex = "0xABCD";
+			expect(pad(hex, 4)).toBe("0x0000abcd");
+		});
+
+		it("converts mixed case to lowercase", () => {
+			const hex = "0xAbCd";
+			expect(pad(hex, 4)).toBe("0x0000abcd");
+		});
+	});
+
+	describe("type safety", () => {
+		it("returns HexType branded string", () => {
+			const hex = "0x12";
+			const padded = pad(hex, 4);
+			expect(typeof padded).toBe("string");
+			expect(padded.startsWith("0x")).toBe(true);
+		});
+	});
+});

--- a/src/primitives/Hex/padRight.js
+++ b/src/primitives/Hex/padRight.js
@@ -1,3 +1,4 @@
+import { InvalidSizeError } from "./errors.js";
 import { fromBytes } from "./fromBytes.js";
 import { toBytes } from "./toBytes.js";
 
@@ -9,7 +10,7 @@ import { toBytes } from "./toBytes.js";
  * @param {string} hex - Hex string to pad
  * @param {number} targetSize - Target size in bytes
  * @returns {string} Right-padded hex string
- * @throws {never}
+ * @throws {InvalidSizeError} If targetSize is negative or non-integer
  * @example
  * ```javascript
  * import * as Hex from './primitives/Hex/index.js';
@@ -18,6 +19,16 @@ import { toBytes } from "./toBytes.js";
  * ```
  */
 export function padRight(hex, targetSize) {
+	if (targetSize < 0 || !Number.isInteger(targetSize)) {
+		throw new InvalidSizeError(
+			`Size must be a non-negative integer, got ${targetSize}`,
+			{
+				value: targetSize,
+				expected: "non-negative integer",
+				context: { targetSize },
+			},
+		);
+	}
 	// Normalize odd-length hex by padding with trailing 0
 	let normalized = hex;
 	if (hex.length % 2 !== 0) {

--- a/src/primitives/Hex/padRight.test.js
+++ b/src/primitives/Hex/padRight.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InvalidSizeError } from "./errors.js";
 import { padRight } from "./padRight.js";
 
 describe("Hex.padRight", () => {
@@ -46,6 +47,20 @@ describe("Hex.padRight", () => {
 		it("pads to zero size returns original", () => {
 			const hex = "0x1234";
 			expect(padRight(hex, 0)).toBe("0x1234");
+		});
+
+		it("throws for negative size", () => {
+			expect(() => padRight("0x1234", -1)).toThrow(InvalidSizeError);
+			expect(() => padRight("0x1234", -1)).toThrow(
+				"Size must be a non-negative integer",
+			);
+		});
+
+		it("throws for non-integer size", () => {
+			expect(() => padRight("0x1234", 1.5)).toThrow(InvalidSizeError);
+			expect(() => padRight("0x1234", 1.5)).toThrow(
+				"Size must be a non-negative integer",
+			);
 		});
 
 		it("pads odd hex preserves data", () => {


### PR DESCRIPTION
## Summary
- Fixes #96
- Hex.pad (padLeft) and Hex.padRight now validate size is a non-negative integer
- Added InvalidSizeError to errors.js and errors.ts
- Throws InvalidSizeError for negative or non-integer sizes

## Test plan
- [x] Added tests for invalid size values (-1, 1.5)
- [x] Ran Hex tests - all 827 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)