### PR TITLE
fix: Parse decimal strings in Wei.fromEther

### DIFF
--- a/docs/primitives/denomination/index.test.ts
+++ b/docs/primitives/denomination/index.test.ts
@@ -66,7 +66,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const wei = Wei(1_000_000_000_000_000_000n); // 1 ETH in Wei
 			const ether = Wei.toEther(wei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 
 		it("should convert Ether to Wei", async () => {
@@ -88,7 +88,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const gwei = Gwei(1_000_000_000n); // 1 ETH in Gwei
 			const ether = Gwei.toEther(gwei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 
 		it("should convert Ether to Gwei", async () => {
@@ -254,7 +254,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const wei = Wei(1_000_000_000_000_000_000n);
 			const ether = Wei.toEther(wei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 	});
 
@@ -305,7 +305,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const gwei = Gwei(1_000_000_000n);
 			const ether = Gwei.toEther(gwei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 	});
 
@@ -316,7 +316,7 @@ describe("Denomination Documentation - index.mdx", () => {
 			);
 
 			const ether = Ether.from(1n);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 
 		it("should have fromWei() method", async () => {
@@ -326,7 +326,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const wei = Wei(1_000_000_000_000_000_000n);
 			const ether = Ether.fromWei(wei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 
 		it("should have fromGwei() method", async () => {
@@ -336,7 +336,7 @@ describe("Denomination Documentation - index.mdx", () => {
 
 			const gwei = Gwei(1_000_000_000n);
 			const ether = Ether.fromGwei(gwei);
-			expect(ether).toBe(1n);
+			expect(ether).toBe("1"); // Ether is a string type to support decimals
 		});
 
 		it("should have toWei() method", async () => {

--- a/src/primitives/Denomination/Ether.js
+++ b/src/primitives/Denomination/Ether.js
@@ -22,81 +22,150 @@ import * as Uint from "../Uint/index.js";
 
 const WEI_PER_ETHER = 1_000_000_000_000_000_000n;
 const GWEI_PER_ETHER = 1_000_000_000n;
+const DECIMALS = 18;
 
 /**
  * Creates an Ether value from bigint, number, or string
+ * Supports decimal strings like "1.5" or "0.001"
  *
  * @param {bigint | number | string} value
  * @returns {Ether}
  */
 export function from(value) {
-	return /** @type {Ether} */ (/** @type {unknown} */ (Uint.from(value)));
+	if (typeof value === "bigint") {
+		return /** @type {Ether} */ (value.toString());
+	}
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) {
+			throw new Error(`Invalid Ether value: ${value}`);
+		}
+		return /** @type {Ether} */ (value.toString());
+	}
+	// string - validate it's a valid number
+	const trimmed = value.trim();
+	if (trimmed === "" || Number.isNaN(Number(trimmed))) {
+		throw new Error(`Invalid Ether value: ${value}`);
+	}
+	return /** @type {Ether} */ (trimmed);
 }
 
 /**
  * Creates Ether from Wei value
+ * Returns a string with proper decimal representation
  *
  * @param {Wei} wei
  * @returns {Ether}
  */
 export function fromWei(wei) {
-	const ether = Uint.dividedBy(
-		/** @type {Uint.Type} */ (/** @type {unknown} */ (wei)),
-		Uint.from(WEI_PER_ETHER),
-	);
-	return /** @type {Ether} */ (/** @type {unknown} */ (ether));
+	const weiValue = BigInt(wei);
+	const intPart = weiValue / WEI_PER_ETHER;
+	const decPart = weiValue % WEI_PER_ETHER;
+
+	if (decPart === 0n) {
+		return /** @type {Ether} */ (intPart.toString());
+	}
+
+	// Convert decimal part to string with leading zeros
+	const decStr = decPart.toString().padStart(DECIMALS, "0");
+	// Remove trailing zeros
+	const trimmedDec = decStr.replace(/0+$/, "");
+	return /** @type {Ether} */ (`${intPart}.${trimmedDec}`);
 }
+
+const GWEI_DECIMALS = 9;
 
 /**
  * Creates Ether from Gwei value
+ * Returns a string with proper decimal representation
  *
  * @param {Gwei} gwei
  * @returns {Ether}
  */
 export function fromGwei(gwei) {
-	const ether = Uint.dividedBy(
-		/** @type {Uint.Type} */ (/** @type {unknown} */ (gwei)),
-		Uint.from(GWEI_PER_ETHER),
-	);
-	return /** @type {Ether} */ (/** @type {unknown} */ (ether));
+	const gweiValue = BigInt(gwei);
+	const intPart = gweiValue / GWEI_PER_ETHER;
+	const decPart = gweiValue % GWEI_PER_ETHER;
+
+	if (decPart === 0n) {
+		return /** @type {Ether} */ (intPart.toString());
+	}
+
+	// Convert decimal part to string with leading zeros
+	const decStr = decPart.toString().padStart(GWEI_DECIMALS, "0");
+	// Remove trailing zeros
+	const trimmedDec = decStr.replace(/0+$/, "");
+	return /** @type {Ether} */ (`${intPart}.${trimmedDec}`);
 }
 
 /**
  * Converts Ether to Wei
+ * Supports decimal strings like "1.5" or "0.001"
  *
  * @param {Ether} ether
  * @returns {Wei}
  */
 export function toWei(ether) {
-	const wei = Uint.times(
-		/** @type {Uint.Type} */ (/** @type {unknown} */ (ether)),
-		Uint.from(WEI_PER_ETHER),
-	);
-	return /** @type {Wei} */ (/** @type {unknown} */ (wei));
+	const str = String(ether);
+	const [intPart, decPart = ""] = str.split(".");
+
+	if (decPart.length > DECIMALS) {
+		throw new Error(
+			`Ether value has too many decimal places (max ${DECIMALS}): ${ether}`,
+		);
+	}
+
+	// Pad decimal part to 18 digits
+	const paddedDec = decPart.padEnd(DECIMALS, "0");
+
+	// Combine integer and decimal parts
+	const combined = intPart + paddedDec;
+
+	// Remove leading zeros and convert to bigint
+	const wei = BigInt(combined.replace(/^0+/, "") || "0");
+
+	return /** @type {Wei} */ (wei);
 }
 
 /**
  * Converts Ether to Gwei
+ * Supports decimal strings like "1.5" or "0.001"
  *
  * @param {Ether} ether
  * @returns {Gwei}
  */
 export function toGwei(ether) {
-	const gwei = Uint.times(
-		/** @type {Uint.Type} */ (/** @type {unknown} */ (ether)),
-		Uint.from(GWEI_PER_ETHER),
-	);
+	const str = String(ether);
+	const [intPart, decPart = ""] = str.split(".");
+
+	if (decPart.length > GWEI_DECIMALS) {
+		throw new Error(
+			`Ether value has too many decimal places for Gwei conversion (max ${GWEI_DECIMALS}): ${ether}`,
+		);
+	}
+
+	// Pad decimal part to 9 digits (gwei has 9 decimal places)
+	const paddedDec = decPart.padEnd(GWEI_DECIMALS, "0");
+
+	// Combine integer and decimal parts
+	const combined = intPart + paddedDec;
+
+	// Remove leading zeros and convert to bigint
+	const gwei = BigInt(combined.replace(/^0+/, "") || "0");
+
 	return /** @type {Gwei} */ (/** @type {unknown} */ (gwei));
 }
 
 /**
- * Converts Ether to Uint256
+ * Converts Ether to Uint256 (as Wei)
+ * Parses decimal strings and returns the Wei value as Uint256
  *
  * @param {Ether} ether
  * @returns {Uint.Type}
  */
 export function toU256(ether) {
-	return /** @type {Uint.Type} */ (/** @type {unknown} */ (ether));
+	// Convert to Wei first (which handles decimals), then cast to Uint
+	const wei = toWei(ether);
+	return /** @type {Uint.Type} */ (/** @type {unknown} */ (wei));
 }
 
 /**

--- a/src/primitives/Denomination/Wei.test.ts
+++ b/src/primitives/Denomination/Wei.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { Gwei, Wei } from "./index.js";
+import { Ether, Gwei, Wei } from "./index.js";
 
 describe("Wei", () => {
 	it("creates Wei from bigint", () => {
@@ -26,7 +26,50 @@ describe("Wei", () => {
 	it("converts Wei to Ether", () => {
 		const wei = Wei(1_000_000_000_000_000_000n);
 		const ether = Wei.toEther(wei);
-		expect(ether).toBe(1n);
+		expect(ether).toBe("1"); // Ether is a string type to support decimals
+	});
+
+	describe("fromEther", () => {
+		it("converts 1 Ether to Wei", () => {
+			const ether = Ether("1");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(1_000_000_000_000_000_000n);
+		});
+
+		it("converts decimal string 1.5 ETH to Wei", () => {
+			const ether = Ether("1.5");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(1_500_000_000_000_000_000n);
+		});
+
+		it("converts decimal string 0.001 ETH to Wei", () => {
+			const ether = Ether("0.001");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(1_000_000_000_000_000n);
+		});
+
+		it("converts 18 decimal places", () => {
+			const ether = Ether("1.000000000000000001");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(1_000_000_000_000_000_001n);
+		});
+
+		it("converts small decimal 0.000000000000000001 ETH (1 wei)", () => {
+			const ether = Ether("0.000000000000000001");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(1n);
+		});
+
+		it("converts 0 Ether to 0 Wei", () => {
+			const ether = Ether("0");
+			const wei = Wei.fromEther(ether);
+			expect(wei).toBe(0n);
+		});
+
+		it("throws for more than 18 decimal places", () => {
+			const ether = Ether("1.0000000000000000001");
+			expect(() => Wei.fromEther(ether)).toThrow("too many decimal places");
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary
- Fixes #150
- Wei.fromEther() now accepts decimal strings like '1.5', '0.001'
- Properly converts to wei (1.5 ETH = 1500000000000000000 wei)
- Ether type is now string-based to support decimal representations

## Changes
- Fixed `Wei.fromEther()`, `Wei.toEther()`
- Fixed `Ether.from()`, `Ether.toWei()`, `Ether.toGwei()`, `Ether.fromWei()`, `Ether.fromGwei()`
- Fixed `Gwei.fromEther()`, `Gwei.toEther()`
- Updated tests to expect string Ether values

## Test plan
- [x] Added tests for decimal strings ('1.5', '0.001', '1.000000000000000001')
- [x] Ran Denomination tests (all 165 tests pass)
- [x] Ran full test suite (22125 tests pass)

🤖 Generated with [Claude Code](https://claude.ai/code)