### PR TITLE
feat: Add Bytes.constantTimeEquals for timing-safe comparison

### DIFF
--- a/src/primitives/Bytes/Bytes.index.ts
+++ b/src/primitives/Bytes/Bytes.index.ts
@@ -5,6 +5,7 @@ import { assert } from "./assert.js";
 import { clone } from "./clone.js";
 import { compare } from "./compare.js";
 import { concat } from "./concat.js";
+import { constantTimeEquals } from "./constantTimeEquals.js";
 import { equals } from "./equals.js";
 import { from } from "./from.js";
 import { fromBigInt } from "./fromBigInt.js";
@@ -33,6 +34,7 @@ export {
 	clone,
 	compare,
 	concat,
+	constantTimeEquals,
 	equals,
 	from,
 	fromBigInt,
@@ -61,6 +63,7 @@ export const BytesType = {
 	clone,
 	compare,
 	concat,
+	constantTimeEquals,
 	equals,
 	from,
 	fromBigInt,

--- a/src/primitives/Bytes/constantTimeEquals.js
+++ b/src/primitives/Bytes/constantTimeEquals.js
@@ -1,0 +1,29 @@
+/**
+ * Constant-time comparison of two Bytes arrays.
+ * Prevents timing attacks by always comparing in O(max(a.length, b.length)) time,
+ * regardless of where differences occur or if lengths differ.
+ *
+ * @param {import('./BytesType.js').BytesType} a - First Bytes
+ * @param {import('./BytesType.js').BytesType} b - Second Bytes
+ * @returns {boolean} True if equal
+ *
+ * @example
+ * ```typescript
+ * // Use for security-sensitive comparisons (e.g., HMAC, signatures)
+ * const equal = Bytes.constantTimeEquals(secret1, secret2);
+ * ```
+ */
+export function constantTimeEquals(a, b) {
+	const maxLen = Math.max(a.length, b.length);
+	// XOR lengths - will be non-zero if different
+	let result = a.length ^ b.length;
+
+	for (let i = 0; i < maxLen; i++) {
+		// Use 0 for out-of-bounds access to maintain constant time
+		const ai = i < a.length ? a[i] : 0;
+		const bi = i < b.length ? b[i] : 0;
+		result |= ai ^ bi;
+	}
+
+	return result === 0;
+}

--- a/src/primitives/Bytes/constantTimeEquals.test.ts
+++ b/src/primitives/Bytes/constantTimeEquals.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { constantTimeEquals } from "./constantTimeEquals.js";
+import { from } from "./from.js";
+
+describe("constantTimeEquals", () => {
+	it("returns true for equal arrays", () => {
+		const a = from([1, 2, 3, 4]);
+		const b = from([1, 2, 3, 4]);
+		expect(constantTimeEquals(a, b)).toBe(true);
+	});
+
+	it("returns false for different arrays of same length", () => {
+		const a = from([1, 2, 3, 4]);
+		const b = from([1, 2, 3, 5]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("returns false for arrays of different lengths", () => {
+		const a = from([1, 2, 3]);
+		const b = from([1, 2, 3, 4]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("returns false when first array is longer", () => {
+		const a = from([1, 2, 3, 4, 5]);
+		const b = from([1, 2, 3, 4]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("returns true for empty arrays", () => {
+		const a = from([]);
+		const b = from([]);
+		expect(constantTimeEquals(a, b)).toBe(true);
+	});
+
+	it("returns false comparing empty to non-empty", () => {
+		const a = from([]);
+		const b = from([1]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("returns true for arrays with zeros", () => {
+		const a = from([0, 0, 0]);
+		const b = from([0, 0, 0]);
+		expect(constantTimeEquals(a, b)).toBe(true);
+	});
+
+	it("returns false when arrays differ only in first byte", () => {
+		const a = from([0, 2, 3, 4]);
+		const b = from([1, 2, 3, 4]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("returns false when arrays differ only in last byte", () => {
+		const a = from([1, 2, 3, 4]);
+		const b = from([1, 2, 3, 0]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+
+	it("handles max byte values correctly", () => {
+		const a = from([255, 255, 255]);
+		const b = from([255, 255, 255]);
+		expect(constantTimeEquals(a, b)).toBe(true);
+	});
+
+	it("detects difference with max byte values", () => {
+		const a = from([255, 255, 255]);
+		const b = from([255, 254, 255]);
+		expect(constantTimeEquals(a, b)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #109
- Adds `Bytes.constantTimeEquals()` for security-sensitive comparisons
- Uses constant-time XOR comparison to prevent timing attacks
- Compares in O(max(a.length, b.length)) time regardless of where differences occur

## Test plan
- [x] Added tests for equal arrays
- [x] Added tests for different arrays (same/different lengths)
- [x] Added tests for edge cases (empty, zeros, max byte values)
- [x] Ran Bytes test suite

🤖 Generated with [Claude Code](https://claude.ai/code)