### PR TITLE
test: Add explicit tests for Bytes32.from() size validation

### DIFF
--- a/src/primitives/Bytes32/Bytes32.test.ts
+++ b/src/primitives/Bytes32/Bytes32.test.ts
@@ -144,6 +144,26 @@ describe("Bytes32", () => {
 			const result = Bytes32.from(42n);
 			expect(result[31]).toBe(42);
 		});
+
+		it("should throw on oversized bytes input", () => {
+			expect(() => Bytes32.from(new Uint8Array(33))).toThrow();
+			expect(() => Bytes32.from(new Uint8Array(64))).toThrow();
+		});
+
+		it("should throw on oversized hex input", () => {
+			expect(() => Bytes32.from(`0x${"aa".repeat(33)}`)).toThrow();
+			expect(() => Bytes32.from(`0x${"aa".repeat(64)}`)).toThrow();
+		});
+
+		it("should throw on undersized bytes input", () => {
+			expect(() => Bytes32.from(new Uint8Array(31))).toThrow();
+			expect(() => Bytes32.from(new Uint8Array(0))).toThrow();
+		});
+
+		it("should throw on undersized hex input", () => {
+			expect(() => Bytes32.from("0xaa")).toThrow();
+			expect(() => Bytes32.from(`0x${"aa".repeat(31)}`)).toThrow();
+		});
 	});
 
 	describe("toHex", () => {


### PR DESCRIPTION
## Summary
- Closes #98
- Bytes32.from() already correctly throws for oversized/undersized input (validation was never missing)
- Added explicit test coverage for the universal constructor's size validation

## Test plan
- [x] Added tests for oversized bytes input (33, 64 bytes) rejection
- [x] Added tests for oversized hex input rejection
- [x] Added tests for undersized bytes input rejection
- [x] Added tests for undersized hex input rejection
- [x] All 71 Bytes32 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)