### PR TITLE
fix: Validate Log topics are 32-byte hex strings

### DIFF
--- a/src/primitives/EventLog/from.js
+++ b/src/primitives/EventLog/from.js
@@ -2,7 +2,74 @@
  * @typedef {import('./EventLogType.js').EventLogType} BrandedEventLog
  */
 
+import { InvalidFormatError, InvalidLengthError } from "../errors/index.js";
 import { create } from "./create.js";
+
+const HASH_SIZE = 32;
+
+/**
+ * Validate a topic is a valid 32-byte hash
+ *
+ * @param {unknown} topic - Topic to validate
+ * @param {number} index - Topic index for error messages
+ * @throws {InvalidLengthError} If topic is wrong length
+ * @throws {InvalidFormatError} If topic is invalid format
+ */
+function validateTopic(topic, index) {
+	if (topic instanceof Uint8Array) {
+		if (topic.length !== HASH_SIZE) {
+			throw new InvalidLengthError(
+				`Topic at index ${index} must be ${HASH_SIZE} bytes, got ${topic.length}`,
+				{
+					code: "EVENTLOG_INVALID_TOPIC_LENGTH",
+					value: topic,
+					expected: `${HASH_SIZE} bytes`,
+					context: { index, actualLength: topic.length },
+					docsPath: "/primitives/eventlog",
+				},
+			);
+		}
+		return;
+	}
+	if (typeof topic === "string") {
+		const normalized = topic.startsWith("0x") ? topic.slice(2) : topic;
+		if (normalized.length !== HASH_SIZE * 2) {
+			throw new InvalidLengthError(
+				`Topic at index ${index} must be ${HASH_SIZE * 2} hex characters, got ${normalized.length}`,
+				{
+					code: "EVENTLOG_INVALID_TOPIC_LENGTH",
+					value: topic,
+					expected: `${HASH_SIZE * 2} hex characters`,
+					context: { index, actualLength: normalized.length },
+					docsPath: "/primitives/eventlog",
+				},
+			);
+		}
+		if (!/^[0-9a-fA-F]+$/.test(normalized)) {
+			throw new InvalidFormatError(
+				`Topic at index ${index} contains invalid hex characters`,
+				{
+					code: "EVENTLOG_INVALID_TOPIC_FORMAT",
+					value: topic,
+					expected: "hexadecimal string",
+					context: { index },
+					docsPath: "/primitives/eventlog",
+				},
+			);
+		}
+		return;
+	}
+	throw new InvalidFormatError(
+		`Topic at index ${index} must be a Uint8Array or hex string`,
+		{
+			code: "EVENTLOG_INVALID_TOPIC_TYPE",
+			value: topic,
+			expected: "Uint8Array or hex string",
+			context: { index, actualType: typeof topic },
+			docsPath: "/primitives/eventlog",
+		},
+	);
+}
 
 /**
  * Create EventLog from parameters
@@ -11,7 +78,8 @@ import { create } from "./create.js";
  * @since 0.0.0
  * @param {Parameters<typeof create>[0]} params - Event log parameters
  * @returns {BrandedEventLog}
- * @throws {never}
+ * @throws {InvalidLengthError} If any topic is wrong length
+ * @throws {InvalidFormatError} If any topic has invalid format
  * @example
  * ```javascript
  * import * as EventLog from './primitives/EventLog/index.js';
@@ -25,5 +93,11 @@ import { create } from "./create.js";
  * ```
  */
 export function from(params) {
+	// Validate topics
+	if (params.topics) {
+		for (let i = 0; i < params.topics.length; i++) {
+			validateTopic(params.topics[i], i);
+		}
+	}
 	return create(params);
 }


### PR DESCRIPTION
## Summary
- Fixes #91
- `Log.from()` now validates topics are valid 32-byte hex strings
- Throws `InvalidLengthError` for wrong length topics
- Throws `InvalidFormatError` for invalid hex characters or wrong types

## Test plan
- [x] Added tests for valid 32-byte Uint8Array topics
- [x] Added tests for valid 64-character hex string topics
- [x] Added tests for hex strings without 0x prefix
- [x] Added tests for topics that are too short (hex string)
- [x] Added tests for topics that are too long (hex string)
- [x] Added tests for topics that are too short (Uint8Array)
- [x] Added tests for topics that are too long (Uint8Array)
- [x] Added tests for invalid hex characters
- [x] Added tests for non-string/non-Uint8Array topics
- [x] Added tests for null topics
- [x] Added tests verifying all topics in array are validated
- [x] Added tests verifying topic index is included in error message
- [x] Ran Log tests - all 73 pass

🤖 Generated with [Claude Code](https://claude.ai/code)