### PR TITLE
fix: Validate CREATE2 salt is exactly 32 bytes

### DIFF
--- a/src/primitives/Address/calculateCreate2Address.js
+++ b/src/primitives/Address/calculateCreate2Address.js
@@ -1,3 +1,5 @@
+import { InvalidLengthError } from "../errors/ValidationError.js";
+
 /**
  * Factory function to create calculateCreate2Address with injected keccak256 dependency
  *
@@ -15,6 +17,7 @@ export function CalculateCreate2Address({ keccak256 }) {
 	 * @param {import('../Hash/HashType.js').HashType} salt - 32-byte salt (use Hash.from to create)
 	 * @param {import('../Bytecode/BytecodeType.js').BrandedBytecode} initCode - Contract initialization code
 	 * @returns {import('./AddressType.js').AddressType} Calculated contract address
+	 * @throws {InvalidLengthError} If salt is not exactly 32 bytes
 	 *
 	 * @example
 	 * ```typescript
@@ -33,6 +36,17 @@ export function CalculateCreate2Address({ keccak256 }) {
 	 * ```
 	 */
 	return function calculateCreate2Address(address, salt, initCode) {
+		// Validate salt is exactly 32 bytes
+		if (salt.length !== 32) {
+			throw new InvalidLengthError("Salt must be exactly 32 bytes", {
+				code: "CREATE2_INVALID_SALT_LENGTH",
+				value: salt,
+				expected: "32 bytes",
+				context: { length: salt.length },
+				docsPath: "/primitives/address/calculate-create2-address#error-handling",
+			});
+		}
+
 		// Hash init code
 		const initCodeHash = keccak256(initCode);
 

--- a/src/primitives/Address/calculateCreate2Address.test.ts
+++ b/src/primitives/Address/calculateCreate2Address.test.ts
@@ -122,6 +122,52 @@ describe("calculateCreate2Address", () => {
 		});
 	});
 
+	describe("salt validation in calculateCreate2Address", () => {
+		it("throws on salt size < 32 bytes", () => {
+			const sender = Address.fromHex(
+				"0x742d35cc6634c0532925a3b844bc9e7595f251e3",
+			);
+			const salt = new Uint8Array(31) as unknown as ReturnType<typeof Hash>;
+			const initCode = Bytecode(new Uint8Array(0));
+			expect(() => calculateCreate2Address(sender, salt, initCode)).toThrow(
+				"Salt must be exactly 32 bytes",
+			);
+		});
+
+		it("throws on salt size > 32 bytes", () => {
+			const sender = Address.fromHex(
+				"0x742d35cc6634c0532925a3b844bc9e7595f251e3",
+			);
+			const salt = new Uint8Array(33) as unknown as ReturnType<typeof Hash>;
+			const initCode = Bytecode(new Uint8Array(0));
+			expect(() => calculateCreate2Address(sender, salt, initCode)).toThrow(
+				"Salt must be exactly 32 bytes",
+			);
+		});
+
+		it("throws on empty salt", () => {
+			const sender = Address.fromHex(
+				"0x742d35cc6634c0532925a3b844bc9e7595f251e3",
+			);
+			const salt = new Uint8Array(0) as unknown as ReturnType<typeof Hash>;
+			const initCode = Bytecode(new Uint8Array(0));
+			expect(() => calculateCreate2Address(sender, salt, initCode)).toThrow(
+				"Salt must be exactly 32 bytes",
+			);
+		});
+
+		it("throws on salt size 64 bytes", () => {
+			const sender = Address.fromHex(
+				"0x742d35cc6634c0532925a3b844bc9e7595f251e3",
+			);
+			const salt = new Uint8Array(64) as unknown as ReturnType<typeof Hash>;
+			const initCode = Bytecode(new Uint8Array(0));
+			expect(() => calculateCreate2Address(sender, salt, initCode)).toThrow(
+				"Salt must be exactly 32 bytes",
+			);
+		});
+	});
+
 	describe("different init codes", () => {
 		it("handles empty init code", () => {
 			const sender = Address.fromHex(


### PR DESCRIPTION
## Summary
- Fixes #127
- CREATE2 salt validation now requires exactly 32 bytes
- Throws `InvalidLengthError` for invalid salt size

## Test plan
- [x] Added tests for invalid salt rejection (31, 33, 0, 64 bytes)
- [x] Ran Address calculateCreate2Address tests (22 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)