### PR TITLE
fix: Validate AccessList storage keys are 32-byte hex

### DIFF
--- a/src/primitives/AccessList/AccessList.test.ts
+++ b/src/primitives/AccessList/AccessList.test.ts
@@ -717,6 +717,55 @@ describe("AccessList.from", () => {
 		expect(result[1]?.address).toEqual(addr2);
 		expect(result[2]?.address).toEqual(addr3);
 	});
+
+	it("throws for invalid storage key (string)", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: ["invalid"] }] as any;
+		expect(() => from(list)).toThrow("Storage key must be exactly 32 bytes");
+	});
+
+	it("throws for invalid storage key (wrong length hex)", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: ["0x123"] }] as any;
+		expect(() => from(list)).toThrow("Storage key must be exactly 32 bytes");
+	});
+
+	it("throws for invalid storage key (empty string)", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: [""] }] as any;
+		expect(() => from(list)).toThrow("Storage key must be exactly 32 bytes");
+	});
+
+	it("throws for storage key with wrong byte length", () => {
+		const wrongLength = new Uint8Array(31);
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: [wrongLength] }] as any;
+		expect(() => from(list)).toThrow("Storage key must be exactly 32 bytes");
+	});
+
+	it("throws for address with wrong byte length", () => {
+		const wrongAddr = new Uint8Array(19);
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: wrongAddr, storageKeys: [] }] as any;
+		expect(() => from(list)).toThrow("Invalid address in access list");
+	});
+
+	it("throws for non-array input", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		expect(() => from({} as any)).toThrow("Access list must be an array");
+	});
+
+	it("throws for item missing address", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ storageKeys: [] }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
+
+	it("throws for item missing storageKeys", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1 }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
 });
 
 // ============================================================================

--- a/src/primitives/AccessList/from.js
+++ b/src/primitives/AccessList/from.js
@@ -1,3 +1,4 @@
+import { InvalidFormatError, InvalidLengthError } from "../errors/index.js";
 import { fromBytes } from "./fromBytes.js";
 
 /**
@@ -5,13 +6,14 @@ import { fromBytes } from "./fromBytes.js";
  *
  * @see https://voltaire.tevm.sh/primitives/accesslist
  * @since 0.0.0
- * @param {readonly import('../BrandedAccessList.js').Item[] | Uint8Array} value - AccessList items or RLP bytes
- * @returns {import('../BrandedAccessList.js').BrandedAccessList} AccessList
- * @throws {never}
+ * @param {readonly import('./AccessListType.js').Item[] | Uint8Array} value - AccessList items or RLP bytes
+ * @returns {import('./AccessListType.js').BrandedAccessList} AccessList
+ * @throws {InvalidFormatError} If structure is invalid
+ * @throws {InvalidLengthError} If address or storage key length is invalid
  * @example
  * ```javascript
  * import * as AccessList from './primitives/AccessList/index.js';
- * const list = AccessList.from([{ address: '0x742d35Cc...', storageKeys: [] }]);
+ * const list = AccessList.from([{ address: addr, storageKeys: [key] }]);
  * const list2 = AccessList.from(bytes); // from RLP bytes
  * ```
  */
@@ -19,5 +21,73 @@ export function from(value) {
 	if (value instanceof Uint8Array) {
 		return fromBytes(value);
 	}
+
+	// Validate array structure
+	if (!Array.isArray(value)) {
+		throw new InvalidFormatError("Access list must be an array", {
+			code: "ACCESS_LIST_INVALID_FORMAT",
+			value: value,
+			expected: "array",
+			docsPath: "/primitives/access-list",
+		});
+	}
+
+	for (const item of value) {
+		// Validate item structure
+		if (
+			!item ||
+			typeof item !== "object" ||
+			!("address" in item) ||
+			!("storageKeys" in item)
+		) {
+			throw new InvalidFormatError("Invalid access list item", {
+				code: "ACCESS_LIST_INVALID_ITEM",
+				value: item,
+				expected: "{ address: Uint8Array(20), storageKeys: Uint8Array(32)[] }",
+				docsPath: "/primitives/access-list",
+			});
+		}
+
+		// Validate address is 20 bytes
+		if (!(item.address instanceof Uint8Array) || item.address.length !== 20) {
+			throw new InvalidLengthError("Invalid address in access list", {
+				code: "ACCESS_LIST_INVALID_ADDRESS_LENGTH",
+				value: item.address,
+				expected: "20 bytes",
+				context: { actualLength: item.address?.length },
+				docsPath: "/primitives/access-list",
+			});
+		}
+
+		// Validate storage keys array
+		if (!Array.isArray(item.storageKeys)) {
+			throw new InvalidFormatError("Storage keys must be an array", {
+				code: "ACCESS_LIST_INVALID_STORAGE_KEYS",
+				value: item.storageKeys,
+				expected: "Uint8Array(32)[]",
+				docsPath: "/primitives/access-list",
+			});
+		}
+
+		// Validate each storage key is exactly 32 bytes
+		for (const key of item.storageKeys) {
+			if (!(key instanceof Uint8Array) || key.length !== 32) {
+				throw new InvalidLengthError(
+					"Storage key must be exactly 32 bytes",
+					{
+						code: "ACCESS_LIST_INVALID_STORAGE_KEY_LENGTH",
+						value: key,
+						expected: "32 bytes",
+						context: {
+							actualLength: key instanceof Uint8Array ? key.length : undefined,
+							actualType: typeof key,
+						},
+						docsPath: "/primitives/access-list",
+					},
+				);
+			}
+		}
+	}
+
 	return value;
 }


### PR DESCRIPTION
## Summary
- Fixes #88
- AccessList.from() now validates storage keys are 32-byte Uint8Arrays
- Also validates addresses are 20-byte Uint8Arrays
- Throws InvalidLengthError for invalid storage key/address lengths
- Throws InvalidFormatError for invalid item structure

## Test plan
- [x] Added tests for invalid storage key rejection (strings, wrong length)
- [x] Added tests for invalid address length
- [x] Added tests for invalid item structure
- [x] Ran AccessList tests - all 98 pass

🤖 Generated with [Claude Code](https://claude.ai/code)