### PR TITLE
fix: Reject negative values in Hex.fromBigInt

### DIFF
--- a/src/primitives/Hex/fromBigInt.js
+++ b/src/primitives/Hex/fromBigInt.js
@@ -3,10 +3,10 @@
  *
  * @see https://voltaire.tevm.sh/primitives/hex for Hex documentation
  * @since 0.0.0
- * @param {bigint} value - BigInt to convert
+ * @param {bigint} value - BigInt to convert (must be non-negative)
  * @param {number} [size] - Optional byte size for padding
  * @returns {import('./HexType.js').HexType} Hex string
- * @throws {never}
+ * @throws {Error} If value is negative
  * @example
  * ```javascript
  * import * as Hex from './primitives/Hex/index.js';
@@ -15,6 +15,9 @@
  * ```
  */
 export function fromBigInt(value, size) {
+	if (value < 0n) {
+		throw new Error(`Cannot convert negative bigint to hex: ${value}`);
+	}
 	let hex = value.toString(16);
 	if (size !== undefined) {
 		hex = hex.padStart(size * 2, "0");

--- a/src/primitives/Hex/fromBigInt.test.ts
+++ b/src/primitives/Hex/fromBigInt.test.ts
@@ -66,9 +66,9 @@ describe("fromBigInt", () => {
 		expect(toBigInt(hex)).toBe(oneEther);
 	});
 
-	it("handles negative bigints (uses default toString)", () => {
-		const hex = fromBigInt(-1n);
-		expect(hex.startsWith("0x")).toBe(true);
-		expect(hex).toBe("0x-1");
+	it("throws for negative bigints", () => {
+		expect(() => fromBigInt(-1n)).toThrow("Cannot convert negative bigint to hex: -1");
+		expect(() => fromBigInt(-255n)).toThrow("Cannot convert negative bigint to hex: -255");
+		expect(() => fromBigInt(-1000000000000000000n)).toThrow("Cannot convert negative bigint to hex");
 	});
 });

--- a/src/primitives/Hex/fromBigInt.ts
+++ b/src/primitives/Hex/fromBigInt.ts
@@ -5,10 +5,10 @@ import type { HexType } from "./HexType.js";
  *
  * @see https://voltaire.tevm.sh/primitives/hex for Hex documentation
  * @since 0.0.0
- * @param value - BigInt to convert
+ * @param value - BigInt to convert (must be non-negative)
  * @param size - Optional byte size for padding
  * @returns Hex string
- * @throws {never}
+ * @throws {Error} If value is negative
  * @example
  * ```typescript
  * import * as Hex from './primitives/Hex/index.js';
@@ -17,6 +17,9 @@ import type { HexType } from "./HexType.js";
  * ```
  */
 export function fromBigInt(value: bigint, size?: number): HexType {
+	if (value < 0n) {
+		throw new Error(`Cannot convert negative bigint to hex: ${value}`);
+	}
 	let hex = value.toString(16);
 	if (size !== undefined) {
 		hex = hex.padStart(size * 2, "0");


### PR DESCRIPTION
## Summary
- Fixes #54
- Hex.fromBigInt now throws for negative values
- Prevents invalid hex like "0x-5"

## Test plan
- [x] Added tests for negative value rejection
- [x] Ran Hex tests (10 tests pass)

🤖 Generated with [Claude Code](https://claude.ai/code)