### PR TITLE
fix: Validate strings in Hex.from()

### DIFF
--- a/src/primitives/Hex/from.js
+++ b/src/primitives/Hex/from.js
@@ -1,4 +1,5 @@
 import { fromBytes } from "./fromBytes.js";
+import { validate } from "./validate.js";
 
 /**
  * Create Hex from string or bytes
@@ -7,7 +8,8 @@ import { fromBytes } from "./fromBytes.js";
  * @since 0.0.0
  * @param {string | Uint8Array} value - Hex string or bytes
  * @returns {import('./HexType.js').HexType} Hex value
- * @throws {never}
+ * @throws {import('./errors.js').InvalidFormatError} If string is missing 0x prefix
+ * @throws {import('./errors.js').InvalidCharacterError} If string contains invalid hex characters
  * @example
  * ```javascript
  * import * as Hex from './primitives/Hex/index.js';
@@ -17,7 +19,7 @@ import { fromBytes } from "./fromBytes.js";
  */
 export function from(value) {
 	if (typeof value === "string") {
-		return /** @type {import('./HexType.js').HexType} */ (value);
+		return /** @type {import('./HexType.js').HexType} */ (validate(value));
 	}
 	return fromBytes(value);
 }

--- a/src/primitives/Hex/from.test.ts
+++ b/src/primitives/Hex/from.test.ts
@@ -1,11 +1,25 @@
 import { describe, expect, it } from "vitest";
 import { from } from "./from.js";
+import { InvalidCharacterError, InvalidFormatError } from "./errors.js";
 
 describe("from", () => {
 	it("accepts hex string", () => {
 		expect(from("0x1234")).toBe("0x1234");
 		expect(from("0xabcdef")).toBe("0xabcdef");
 		expect(from("0x")).toBe("0x");
+	});
+
+	it("throws on invalid strings", () => {
+		expect(() => from("invalid")).toThrow(InvalidFormatError);
+		expect(() => from("hello")).toThrow(InvalidFormatError);
+		expect(() => from("1234")).toThrow(InvalidFormatError);
+		expect(() => from("")).toThrow(InvalidFormatError);
+	});
+
+	it("throws on invalid hex characters", () => {
+		expect(() => from("0xGG")).toThrow(InvalidCharacterError);
+		expect(() => from("0xZZZZ")).toThrow(InvalidCharacterError);
+		expect(() => from("0x12GH")).toThrow(InvalidCharacterError);
 	});
 
 	it("accepts Uint8Array", () => {


### PR DESCRIPTION
## Summary
- Fixes #53
- `Hex.from()` now validates strings before branding using existing `validate()` function
- Throws `InvalidFormatError` for missing `0x` prefix
- Throws `InvalidCharacterError` for invalid hex characters (e.g., `0xGG`)

## Test plan
- [x] Added tests for invalid string rejection (`"invalid"`, `"hello"`, `"1234"`, `""`)
- [x] Added tests for invalid hex character rejection (`"0xGG"`, `"0xZZZZ"`, `"0x12GH"`)
- [x] All 8 tests in `from.test.ts` pass
- [x] Ran full test suite - 22120 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)