### PR TITLE
fix: Ensure Uint.toBytes produces big-endian output

### DIFF
--- a/src/primitives/Uint128/Uint128.test.ts
+++ b/src/primitives/Uint128/Uint128.test.ts
@@ -226,6 +226,20 @@ describe("Uint128 - toBytes", () => {
 		const restored = Uint128.fromBytes(bytes);
 		expect(restored).toBe(original);
 	});
+
+	it("produces big-endian output (most significant byte first)", () => {
+		// Uint128(0x0102030405060708) should produce big-endian bytes
+		// NOT little-endian
+		const bytes = Uint128.toBytes(Uint128.from(0x0102030405060708n));
+		expect(bytes[8]).toBe(0x01);
+		expect(bytes[9]).toBe(0x02);
+		expect(bytes[10]).toBe(0x03);
+		expect(bytes[11]).toBe(0x04);
+		expect(bytes[12]).toBe(0x05);
+		expect(bytes[13]).toBe(0x06);
+		expect(bytes[14]).toBe(0x07);
+		expect(bytes[15]).toBe(0x08);
+	});
 });
 
 describe("Uint128 - toAbiEncoded", () => {

--- a/src/primitives/Uint16/Uint16.test.ts
+++ b/src/primitives/Uint16/Uint16.test.ts
@@ -190,6 +190,18 @@ describe("Uint16", () => {
 				new Uint8Array([0x12, 0x34]),
 			);
 		});
+
+		it("should produce big-endian output (most significant byte first)", () => {
+			// Uint16(256) = 0x0100 should produce [0x01, 0x00] in big-endian
+			// NOT [0x00, 0x01] which would be little-endian
+			expect(Uint16.toBytes(Uint16.from(256))).toEqual(
+				new Uint8Array([0x01, 0x00]),
+			);
+			// Uint16(0x0102) should produce [0x01, 0x02]
+			expect(Uint16.toBytes(Uint16.from(0x0102))).toEqual(
+				new Uint8Array([0x01, 0x02]),
+			);
+		});
 	});
 
 	describe("toString", () => {

--- a/src/primitives/Uint32/Uint32.test.ts
+++ b/src/primitives/Uint32/Uint32.test.ts
@@ -246,6 +246,13 @@ describe("Uint32.toBytes", () => {
 		const restored = Uint32.fromBytes(bytes);
 		expect(restored).toBe(original);
 	});
+
+	it("produces big-endian output (most significant byte first)", () => {
+		// Uint32(0x01020304) should produce [0x01, 0x02, 0x03, 0x04] in big-endian
+		// NOT [0x04, 0x03, 0x02, 0x01] which would be little-endian
+		const bytes = Uint32.toBytes(Uint32.from(0x01020304));
+		expect(bytes).toEqual(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+	});
 });
 
 describe("Uint32.toAbiEncoded", () => {


### PR DESCRIPTION
## Summary
- Fixes #136
- Verified all Uint.toBytes implementations (Uint8, Uint16, Uint32, Uint64, Uint128, Uint256) produce correct big-endian output
- Added explicit endianness verification tests for Uint16, Uint32, and Uint128
- Uint64 and Uint256 already had explicit big-endian tests

## Findings
All implementations were already correct:
- Uint8: Single byte, no endianness concern
- Uint16: `[(uint >> 8) & 0xff, uint & 0xff]` - big-endian
- Uint32/64/128/256: Loop from `SIZE - 1` down to `0`, filling LSB first - big-endian

Example: `Uint16(256)` correctly produces `[0x01, 0x00]` (big-endian), not `[0x00, 0x01]` (little-endian)

## Test plan
- [x] Added endianness verification tests for Uint16, Uint32, Uint128
- [x] Ran Uint tests: 339 tests passed

🤖 Generated with [Claude Code](https://claude.ai/code)