### PR TITLE
fix: Validate EIP-4844 blob versioned hash version byte

### DIFF
--- a/src/primitives/Transaction/EIP4844/deserialize.js
+++ b/src/primitives/Transaction/EIP4844/deserialize.js
@@ -103,7 +103,7 @@ export function deserialize(data) {
 		});
 	}
 	const blobVersionedHashes = blobHashesData.value.map(
-		(/** @type {any} */ hashData) => {
+		(/** @type {any} */ hashData, /** @type {number} */ index) => {
 			if (hashData.type !== "bytes" || hashData.value.length !== 32) {
 				throw new DecodingError("Invalid blob versioned hash", {
 					code: "INVALID_BLOB_HASH",
@@ -111,6 +111,22 @@ export function deserialize(data) {
 					docsPath:
 						"/primitives/transaction/eip4844/deserialize#error-handling",
 				});
+			}
+			// EIP-4844 requires version byte 0x01
+			if (hashData.value[0] !== 0x01) {
+				throw new DecodingError(
+					`Invalid blob versioned hash version byte at index ${index}: expected 0x01, got 0x${hashData.value[0].toString(16).padStart(2, "0")}`,
+					{
+						code: "INVALID_BLOB_VERSION_BYTE",
+						context: {
+							index,
+							expected: 0x01,
+							actual: hashData.value[0],
+						},
+						docsPath:
+							"/primitives/transaction/eip4844/deserialize#error-handling",
+					},
+				);
 			}
 			return /** @type {import('../../Hash/index.js').HashType} */ (
 				hashData.value


### PR DESCRIPTION
## Summary
- Fixes #63
- Validates blob versioned hashes start with 0x01 per EIP-4844
- Throws DecodingError with code INVALID_BLOB_VERSION_BYTE for invalid version byte

## Test plan
- [x] Added tests for invalid version byte (0x00 and 0x02)
- [x] Ran EIP4844 tests - all 7 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)