### PR TITLE
fix: Check bounds before truncation in Int32.from()

### DIFF
--- a/src/primitives/Int32/Int32.test.ts
+++ b/src/primitives/Int32/Int32.test.ts
@@ -74,7 +74,7 @@ describe("Int32", () => {
 			expect(val).toBe(-42);
 		});
 
-		it("should throw IntegerOverflowError on overflow", () => {
+		it("should throw IntegerOverflowError on overflow (bigint)", () => {
 			try {
 				Int32.from(2147483648n);
 				expect.fail("Should throw");
@@ -83,9 +83,45 @@ describe("Int32", () => {
 			}
 		});
 
-		it("should throw IntegerUnderflowError on underflow", () => {
+		it("should throw IntegerUnderflowError on underflow (bigint)", () => {
 			try {
 				Int32.from(-2147483649n);
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerUnderflowError");
+			}
+		});
+
+		it("should throw IntegerOverflowError on overflow (number)", () => {
+			try {
+				Int32.from(2147483648);
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerOverflowError");
+			}
+		});
+
+		it("should throw IntegerUnderflowError on underflow (number)", () => {
+			try {
+				Int32.from(-2147483649);
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerUnderflowError");
+			}
+		});
+
+		it("should throw IntegerOverflowError on overflow (string)", () => {
+			try {
+				Int32.from("2147483648");
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerOverflowError");
+			}
+		});
+
+		it("should throw IntegerUnderflowError on underflow (string)", () => {
+			try {
+				Int32.from("-2147483649");
 				expect.fail("Should throw");
 			} catch (e) {
 				expect((e as Error).name).toBe("IntegerUnderflowError");
@@ -111,8 +147,9 @@ describe("Int32", () => {
 			expect(Int32.fromNumber(-42)).toBe(-42);
 		});
 
-		it("should truncate to 32-bit", () => {
-			expect(Int32.fromNumber(2147483647.5)).toBe(2147483647);
+		it("should truncate fractional part within range", () => {
+			expect(Int32.fromNumber(42.7)).toBe(42);
+			expect(Int32.fromNumber(-42.7)).toBe(-42);
 		});
 
 		it("should throw InvalidFormatError on NaN", () => {
@@ -122,6 +159,24 @@ describe("Int32", () => {
 			} catch (e) {
 				expect((e as Error).name).toBe("InvalidFormatError");
 				expect((e as Error).message).toContain("NaN");
+			}
+		});
+
+		it("should throw IntegerOverflowError on overflow", () => {
+			try {
+				Int32.fromNumber(2147483648);
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerOverflowError");
+			}
+		});
+
+		it("should throw IntegerUnderflowError on underflow", () => {
+			try {
+				Int32.fromNumber(-2147483649);
+				expect.fail("Should throw");
+			} catch (e) {
+				expect((e as Error).name).toBe("IntegerUnderflowError");
 			}
 		});
 	});

--- a/src/primitives/Int32/from.js
+++ b/src/primitives/Int32/from.js
@@ -27,6 +27,21 @@ export function from(value) {
 	let num;
 
 	if (typeof value === "number") {
+		// Check bounds BEFORE truncation to detect overflow
+		if (value > INT32_MAX) {
+			throw new IntegerOverflowError(`Int32 value exceeds maximum: ${value}`, {
+				value,
+				max: INT32_MAX,
+				type: "int32",
+			});
+		}
+		if (value < INT32_MIN) {
+			throw new IntegerUnderflowError(`Int32 value is below minimum: ${value}`, {
+				value,
+				min: INT32_MIN,
+				type: "int32",
+			});
+		}
 		num = value;
 	} else if (typeof value === "bigint") {
 		if (value > BigInt(INT32_MAX)) {
@@ -56,6 +71,21 @@ export function from(value) {
 				docsPath: "/primitives/int32#from",
 			});
 		}
+		// Check bounds BEFORE truncation to detect overflow
+		if (parsed > INT32_MAX) {
+			throw new IntegerOverflowError(`Int32 value exceeds maximum: ${parsed}`, {
+				value: parsed,
+				max: INT32_MAX,
+				type: "int32",
+			});
+		}
+		if (parsed < INT32_MIN) {
+			throw new IntegerUnderflowError(`Int32 value is below minimum: ${parsed}`, {
+				value: parsed,
+				min: INT32_MIN,
+				type: "int32",
+			});
+		}
 		num = parsed;
 	} else {
 		throw new InvalidFormatError(`Cannot convert ${typeof value} to Int32`, {
@@ -65,23 +95,8 @@ export function from(value) {
 		});
 	}
 
-	// Truncate to 32-bit signed integer
+	// Truncate to 32-bit signed integer (bounds already checked above)
 	num = num | 0;
-
-	if (num > INT32_MAX) {
-		throw new IntegerOverflowError(`Int32 value exceeds maximum: ${num}`, {
-			value: num,
-			max: INT32_MAX,
-			type: "int32",
-		});
-	}
-	if (num < INT32_MIN) {
-		throw new IntegerUnderflowError(`Int32 value is below minimum: ${num}`, {
-			value: num,
-			min: INT32_MIN,
-			type: "int32",
-		});
-	}
 
 	return /** @type {import('./Int32Type.js').BrandedInt32} */ (num);
 }

--- a/src/primitives/Int32/fromNumber.js
+++ b/src/primitives/Int32/fromNumber.js
@@ -25,23 +25,24 @@ export function fromNumber(value) {
 		});
 	}
 
-	// Truncate to 32-bit signed integer
-	const num = value | 0;
-
-	if (num > INT32_MAX) {
-		throw new IntegerOverflowError(`Int32 value exceeds maximum: ${num}`, {
-			value: num,
+	// Check bounds BEFORE truncation to detect overflow
+	if (value > INT32_MAX) {
+		throw new IntegerOverflowError(`Int32 value exceeds maximum: ${value}`, {
+			value,
 			max: INT32_MAX,
 			type: "int32",
 		});
 	}
-	if (num < INT32_MIN) {
-		throw new IntegerUnderflowError(`Int32 value is below minimum: ${num}`, {
-			value: num,
+	if (value < INT32_MIN) {
+		throw new IntegerUnderflowError(`Int32 value is below minimum: ${value}`, {
+			value,
 			min: INT32_MIN,
 			type: "int32",
 		});
 	}
+
+	// Truncate to 32-bit signed integer (bounds already checked above)
+	const num = value | 0;
 
 	return /** @type {import('./Int32Type.js').BrandedInt32} */ (num);
 }


### PR DESCRIPTION
## Summary
- Fixes #55
- Int32.from() and Int32.fromNumber() now validate bounds BEFORE truncation with `| 0`
- Prevents silent data corruption for out-of-range values (e.g., 2147483648 no longer silently becomes -2147483648)

## Test plan
- [x] Added tests for overflow/underflow with number, bigint, and string inputs
- [x] Added tests for fromNumber overflow/underflow
- [x] Updated existing truncation test to use in-range value
- [x] All Int32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)