### PR TITLE
fix: Validate v/recovery value in ECDSA public key recovery

### DIFF
--- a/src/crypto/Secp256k1/recoverPublicKey.test.ts
+++ b/src/crypto/Secp256k1/recoverPublicKey.test.ts
@@ -162,6 +162,70 @@ describe("Secp256k1.recoverPublicKey", () => {
 			);
 		});
 
+		it("should throw InvalidSignatureError for v=2", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 2,
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				"Invalid v value: 2",
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=26", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 26,
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				"Invalid v value: 26",
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=29", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 29,
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				"Invalid v value: 29",
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=100", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 100,
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				"Invalid v value: 100",
+			);
+		});
+
 		it("should throw InvalidSignatureError for all-zero r", () => {
 			const message = Hash(sha256(new TextEncoder().encode("test")));
 			const invalidSig = {

--- a/src/crypto/Secp256k1/recoverPublicKeyFromHash.test.ts
+++ b/src/crypto/Secp256k1/recoverPublicKeyFromHash.test.ts
@@ -62,6 +62,62 @@ describe("Secp256k1.recoverPublicKeyFromHash", () => {
 		).toThrow("Invalid v value: 30");
 	});
 
+	it("should throw on invalid v=2", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 2 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 2");
+	});
+
+	it("should throw on invalid v=26", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 26 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 26");
+	});
+
+	it("should throw on invalid v=29", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 29 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 29");
+	});
+
+	it("should throw on invalid v=100", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 100 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 100");
+	});
+
 	it("should handle v values 0 and 1", () => {
 		const hash = Hash.keccak256String("Test");
 		const privateKey = PrivateKey.from(


### PR DESCRIPTION
## Summary
- Fixes #97
- Adds comprehensive test coverage for invalid v values (2, 26, 29, 100)
- The validation logic was already implemented in recoverPublicKey.js and recoverPublicKeyFromHash.js
- Tests verify that InvalidSignatureError is thrown with proper error messages

## Test plan
- [x] Added tests for invalid v values in recoverPublicKey.test.ts
- [x] Added tests for invalid v values in recoverPublicKeyFromHash.test.ts
- [x] All 42 recoverPublicKey tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)