### PR TITLE
fix: Validate PBKDF2 iteration count

### DIFF
--- a/src/crypto/AesGcm/AesGcm.test.ts
+++ b/src/crypto/AesGcm/AesGcm.test.ts
@@ -813,6 +813,40 @@ describe("AesGcm", () => {
 
 			expect(exported1).not.toEqual(exported2);
 		});
+
+		it("throws InvalidIterationCountError for iteration count 0", async () => {
+			const password = "password";
+			const salt = new Uint8Array(16).fill(1);
+
+			try {
+				await AesGcm.deriveKey(password, salt, 0, 256);
+				expect.fail("Should have thrown");
+			} catch (e) {
+				expect((e as Error).name).toBe("InvalidIterationCountError");
+				expect((e as Error).message).toContain("Iteration count must be at least 1");
+			}
+		});
+
+		it("throws InvalidIterationCountError for negative iteration count", async () => {
+			const password = "password";
+			const salt = new Uint8Array(16).fill(1);
+
+			try {
+				await AesGcm.deriveKey(password, salt, -100, 256);
+				expect.fail("Should have thrown");
+			} catch (e) {
+				expect((e as Error).name).toBe("InvalidIterationCountError");
+			}
+		});
+
+		it("accepts iteration count of 1", async () => {
+			const password = "password";
+			const salt = new Uint8Array(16).fill(1);
+
+			const key = await AesGcm.deriveKey(password, salt, 1, 256);
+			expect(key).toBeDefined();
+			expect(key.type).toBe("secret");
+		});
 	});
 
 	describe("integration tests", () => {

--- a/src/crypto/AesGcm/deriveKey.js
+++ b/src/crypto/AesGcm/deriveKey.js
@@ -1,4 +1,4 @@
-import { AesGcmError } from "./errors.js";
+import { AesGcmError, InvalidIterationCountError } from "./errors.js";
 
 /**
  * Derive key from password using PBKDF2
@@ -10,6 +10,7 @@ import { AesGcmError } from "./errors.js";
  * @param {number} iterations - Number of iterations (at least 100000 recommended)
  * @param {128 | 256} bits - Key size in bits (128 or 256)
  * @returns {Promise<CryptoKey>} Derived CryptoKey
+ * @throws {InvalidIterationCountError} If iteration count is less than 1
  * @throws {AesGcmError} If key derivation fails
  * @example
  * ```javascript
@@ -19,6 +20,16 @@ import { AesGcmError } from "./errors.js";
  * ```
  */
 export async function deriveKey(password, salt, iterations, bits) {
+	if (iterations < 1) {
+		throw new InvalidIterationCountError(
+			`Iteration count must be at least 1, got ${iterations}`,
+			{
+				code: "AES_GCM_INVALID_ITERATION_COUNT",
+				context: { iterations, minimum: 1 },
+				docsPath: "/crypto/aes-gcm/derive-key#error-handling",
+			},
+		);
+	}
 	try {
 		const passwordBytes =
 			typeof password === "string"

--- a/src/crypto/AesGcm/errors.js
+++ b/src/crypto/AesGcm/errors.js
@@ -130,3 +130,35 @@ export class DecryptionError extends AesGcmError {
 		this.name = "DecryptionError";
 	}
 }
+
+/**
+ * Invalid iteration count error for PBKDF2 key derivation
+ *
+ * @see https://voltaire.tevm.sh/crypto for crypto documentation
+ * @since 0.0.0
+ * @throws {never}
+ * @example
+ * ```javascript
+ * import { InvalidIterationCountError } from './crypto/AesGcm/index.js';
+ * throw new InvalidIterationCountError('Iteration count must be at least 1', {
+ *   code: 'AES_GCM_INVALID_ITERATION_COUNT',
+ *   context: { iterations: 0, minimum: 1 },
+ *   docsPath: '/crypto/aes-gcm/derive-key#error-handling'
+ * });
+ * ```
+ */
+export class InvalidIterationCountError extends AesGcmError {
+	/**
+	 * @param {string} message
+	 * @param {{code?: string, context?: Record<string, unknown>, docsPath?: string, cause?: Error}} [options]
+	 */
+	constructor(message, options) {
+		super(message, {
+			code: options?.code || "AES_GCM_INVALID_ITERATION_COUNT",
+			context: options?.context,
+			docsPath: options?.docsPath,
+			cause: options?.cause,
+		});
+		this.name = "InvalidIterationCountError";
+	}
+}

--- a/src/crypto/Keystore/encrypt.js
+++ b/src/crypto/Keystore/encrypt.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { encryptAesCtr } from "./aesCtr.js";
-import { EncryptionError } from "./errors.js";
+import { EncryptionError, InvalidIterationCountError } from "./errors.js";
 import { derivePbkdf2, deriveScrypt } from "./kdf.js";
 import { bytesToHex, concat, generateUuid } from "./utils.js";
 
@@ -96,6 +96,10 @@ export async function encrypt(privateKey, password, options = {}) {
 
 		return keystore;
 	} catch (error) {
+		// Re-throw InvalidIterationCountError without wrapping
+		if (error instanceof InvalidIterationCountError) {
+			throw error;
+		}
 		throw new EncryptionError(`Encryption failed: ${error.message}`);
 	}
 }

--- a/src/crypto/Keystore/errors.js
+++ b/src/crypto/Keystore/errors.js
@@ -189,3 +189,33 @@ export class EncryptionError extends KeystoreError {
 		this.name = "EncryptionError";
 	}
 }
+
+/**
+ * Error thrown when PBKDF2 iteration count is invalid
+ *
+ * @see https://voltaire.tevm.sh/crypto/keystore
+ * @since 0.0.0
+ */
+export class InvalidIterationCountError extends KeystoreError {
+	/** @type {number} */
+	iterations;
+
+	/**
+	 * @param {number} iterations
+	 * @param {object} [options]
+	 * @param {string} [options.code]
+	 * @param {Record<string, unknown>} [options.context]
+	 * @param {string} [options.docsPath]
+	 * @param {Error} [options.cause]
+	 */
+	constructor(iterations, options) {
+		super(`Iteration count must be at least 1, got ${iterations}`, {
+			code: options?.code || "INVALID_ITERATION_COUNT",
+			context: { iterations, minimum: 1, ...options?.context },
+			docsPath: options?.docsPath || "/crypto/keystore#error-handling",
+			cause: options?.cause,
+		});
+		this.name = "InvalidIterationCountError";
+		this.iterations = iterations;
+	}
+}

--- a/src/crypto/Keystore/kdf.js
+++ b/src/crypto/Keystore/kdf.js
@@ -2,6 +2,7 @@
 import { pbkdf2 } from "@noble/hashes/pbkdf2.js";
 import { scrypt } from "@noble/hashes/scrypt.js";
 import { sha256 } from "@noble/hashes/sha2.js";
+import { InvalidIterationCountError } from "./errors.js";
 
 /**
  * Derive key using scrypt KDF
@@ -35,11 +36,16 @@ export function deriveScrypt(
  *
  * @param {string | Uint8Array} password - Password
  * @param {Uint8Array} salt - Salt (32 bytes recommended)
- * @param {number} c - Iteration count (default: 262144)
+ * @param {number} c - Iteration count (default: 262144, must be at least 1)
  * @param {number} dklen - Derived key length (default: 32)
  * @returns {Uint8Array} Derived key
+ * @throws {InvalidIterationCountError} If iteration count is less than 1
  */
 export function derivePbkdf2(password, salt, c = 262144, dklen = 32) {
+	if (c < 1) {
+		throw new InvalidIterationCountError(c);
+	}
+
 	const passwordBytes =
 		typeof password === "string"
 			? new TextEncoder().encode(password)


### PR DESCRIPTION
## Summary
- Fixes #119
- PBKDF2 now validates iteration count >= 1 in both AesGcm.deriveKey and Keystore.derivePbkdf2
- Added InvalidIterationCountError class to both modules
- Prevents security issues from invalid iteration counts

## Test plan
- [x] Added tests for iteration count 0 (throws InvalidIterationCountError)
- [x] Added tests for negative iteration count (throws InvalidIterationCountError)
- [x] Added tests for edge case iteration count 1 (allowed)
- [x] Ran AesGcm tests
- [x] Ran Keystore tests

_Note: Claude AI assistant, not @roninjin10 or @fucory_

🤖 Generated with [Claude Code](https://claude.ai/code)