### PR TITLE
fix: Validate HMAC key is not empty

### DIFF
--- a/src/crypto/HMAC/HMAC.js
+++ b/src/crypto/HMAC/HMAC.js
@@ -1,0 +1,50 @@
+// @ts-nocheck
+export { EmptyKeyError } from "./errors.js";
+export {
+	sha256Hmac as sha256,
+	OUTPUT_SIZE as SHA256_OUTPUT_SIZE,
+} from "./sha256.js";
+export {
+	sha512Hmac as sha512,
+	OUTPUT_SIZE as SHA512_OUTPUT_SIZE,
+} from "./sha512.js";
+
+import { EmptyKeyError } from "./errors.js";
+import {
+	sha256Hmac,
+	OUTPUT_SIZE as SHA256_OUTPUT_SIZE,
+} from "./sha256.js";
+import {
+	sha512Hmac,
+	OUTPUT_SIZE as SHA512_OUTPUT_SIZE,
+} from "./sha512.js";
+
+/**
+ * HMAC - Hash-based Message Authentication Code
+ *
+ * Secure HMAC implementation with key validation.
+ * Empty keys are rejected to prevent security vulnerabilities.
+ *
+ * @see https://voltaire.tevm.sh/crypto for crypto documentation
+ * @since 0.1.42
+ * @example
+ * ```javascript
+ * import { HMAC } from '@voltaire/crypto';
+ *
+ * const key = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+ * const message = new Uint8Array([104, 101, 108, 108, 111]);
+ *
+ * // HMAC-SHA256 (32 bytes)
+ * const mac256 = HMAC.sha256(key, message);
+ *
+ * // HMAC-SHA512 (64 bytes)
+ * const mac512 = HMAC.sha512(key, message);
+ * ```
+ */
+export const HMAC = {
+	sha256: sha256Hmac,
+	sha512: sha512Hmac,
+	SHA256_OUTPUT_SIZE,
+	SHA512_OUTPUT_SIZE,
+	EmptyKeyError,
+};

--- a/src/crypto/HMAC/HMAC.test.ts
+++ b/src/crypto/HMAC/HMAC.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { HMAC, EmptyKeyError } from "./index.js";
+
+describe("HMAC", () => {
+	describe("sha256", () => {
+		it("computes correct HMAC-SHA256", () => {
+			const key = new Uint8Array([
+				0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+				0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+			]);
+			const message = new TextEncoder().encode("Hi There");
+			const mac = HMAC.sha256(key, message);
+
+			expect(mac.length).toBe(32);
+			expect(mac).toBeInstanceOf(Uint8Array);
+		});
+
+		it("rejects empty key", () => {
+			const key = new Uint8Array(0);
+			const message = new TextEncoder().encode("test");
+
+			expect(() => HMAC.sha256(key, message)).toThrow(EmptyKeyError);
+			expect(() => HMAC.sha256(key, message)).toThrow(
+				"HMAC key cannot be empty",
+			);
+		});
+
+		it("accepts single-byte key", () => {
+			const key = new Uint8Array([0x42]);
+			const message = new TextEncoder().encode("test");
+			const mac = HMAC.sha256(key, message);
+
+			expect(mac.length).toBe(32);
+		});
+
+		it("handles empty message", () => {
+			const key = new Uint8Array([1, 2, 3, 4]);
+			const message = new Uint8Array(0);
+			const mac = HMAC.sha256(key, message);
+
+			expect(mac.length).toBe(32);
+		});
+
+		it("produces different outputs for different keys", () => {
+			const message = new TextEncoder().encode("test");
+			const mac1 = HMAC.sha256(new Uint8Array([1]), message);
+			const mac2 = HMAC.sha256(new Uint8Array([2]), message);
+
+			expect(mac1).not.toEqual(mac2);
+		});
+
+		it("produces different outputs for different messages", () => {
+			const key = new Uint8Array([1, 2, 3, 4]);
+			const mac1 = HMAC.sha256(key, new TextEncoder().encode("test1"));
+			const mac2 = HMAC.sha256(key, new TextEncoder().encode("test2"));
+
+			expect(mac1).not.toEqual(mac2);
+		});
+	});
+
+	describe("sha512", () => {
+		it("computes correct HMAC-SHA512", () => {
+			const key = new Uint8Array([
+				0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+				0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+			]);
+			const message = new TextEncoder().encode("Hi There");
+			const mac = HMAC.sha512(key, message);
+
+			expect(mac.length).toBe(64);
+			expect(mac).toBeInstanceOf(Uint8Array);
+		});
+
+		it("rejects empty key", () => {
+			const key = new Uint8Array(0);
+			const message = new TextEncoder().encode("test");
+
+			expect(() => HMAC.sha512(key, message)).toThrow(EmptyKeyError);
+			expect(() => HMAC.sha512(key, message)).toThrow(
+				"HMAC key cannot be empty",
+			);
+		});
+
+		it("accepts single-byte key", () => {
+			const key = new Uint8Array([0x42]);
+			const message = new TextEncoder().encode("test");
+			const mac = HMAC.sha512(key, message);
+
+			expect(mac.length).toBe(64);
+		});
+	});
+
+	describe("EmptyKeyError", () => {
+		it("has correct name", () => {
+			const error = new EmptyKeyError();
+			expect(error.name).toBe("EmptyKeyError");
+		});
+
+		it("has correct message", () => {
+			const error = new EmptyKeyError();
+			expect(error.message).toBe("HMAC key cannot be empty");
+		});
+
+		it("accepts custom message", () => {
+			const error = new EmptyKeyError("Custom error message");
+			expect(error.message).toBe("Custom error message");
+		});
+
+		it("is instance of Error", () => {
+			const error = new EmptyKeyError();
+			expect(error).toBeInstanceOf(Error);
+		});
+	});
+
+	describe("constants", () => {
+		it("exports SHA256_OUTPUT_SIZE", () => {
+			expect(HMAC.SHA256_OUTPUT_SIZE).toBe(32);
+		});
+
+		it("exports SHA512_OUTPUT_SIZE", () => {
+			expect(HMAC.SHA512_OUTPUT_SIZE).toBe(64);
+		});
+	});
+});

--- a/src/crypto/HMAC/HMACType.ts
+++ b/src/crypto/HMAC/HMACType.ts
@@ -1,0 +1,7 @@
+/**
+ * HMAC - Branded type for HMAC authentication codes
+ *
+ * @see https://voltaire.tevm.sh/crypto for crypto documentation
+ * @since 0.1.42
+ */
+export type HMACType = Uint8Array & { readonly __tag: "HMAC" };

--- a/src/crypto/HMAC/errors.js
+++ b/src/crypto/HMAC/errors.js
@@ -1,0 +1,18 @@
+/**
+ * HMAC Error classes
+ *
+ * @module HMAC/errors
+ */
+
+/**
+ * Error thrown when HMAC key is empty
+ */
+export class EmptyKeyError extends Error {
+	/**
+	 * @param {string} [message]
+	 */
+	constructor(message = "HMAC key cannot be empty") {
+		super(message);
+		this.name = "EmptyKeyError";
+	}
+}

--- a/src/crypto/HMAC/index.ts
+++ b/src/crypto/HMAC/index.ts
@@ -1,0 +1,2 @@
+export * from "./HMAC.js";
+export type { HMACType } from "./HMACType.js";

--- a/src/crypto/HMAC/sha256.js
+++ b/src/crypto/HMAC/sha256.js
@@ -1,0 +1,36 @@
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { EmptyKeyError } from "./errors.js";
+
+/**
+ * HMAC-SHA256 output size in bytes
+ */
+export const OUTPUT_SIZE = 32;
+
+/**
+ * Compute HMAC-SHA256 authentication code
+ *
+ * @see https://voltaire.tevm.sh/crypto for crypto documentation
+ * @since 0.1.42
+ * @param {Uint8Array} key - Secret key (must not be empty)
+ * @param {Uint8Array} message - Message to authenticate
+ * @returns {import('./HMACType.js').HMACType} 32-byte HMAC
+ * @throws {EmptyKeyError} If key is empty
+ * @example
+ * ```javascript
+ * import { HMAC } from '@voltaire/crypto';
+ *
+ * const key = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+ * const message = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+ * const mac = HMAC.sha256(key, message);
+ * ```
+ */
+export function sha256Hmac(key, message) {
+	if (key.length === 0) {
+		throw new EmptyKeyError();
+	}
+
+	return /** @type {import('./HMACType.js').HMACType} */ (
+		hmac(sha256, key, message)
+	);
+}

--- a/src/crypto/HMAC/sha512.js
+++ b/src/crypto/HMAC/sha512.js
@@ -1,0 +1,36 @@
+import { hmac } from "@noble/hashes/hmac.js";
+import { sha512 } from "@noble/hashes/sha2.js";
+import { EmptyKeyError } from "./errors.js";
+
+/**
+ * HMAC-SHA512 output size in bytes
+ */
+export const OUTPUT_SIZE = 64;
+
+/**
+ * Compute HMAC-SHA512 authentication code
+ *
+ * @see https://voltaire.tevm.sh/crypto for crypto documentation
+ * @since 0.1.42
+ * @param {Uint8Array} key - Secret key (must not be empty)
+ * @param {Uint8Array} message - Message to authenticate
+ * @returns {import('./HMACType.js').HMACType} 64-byte HMAC
+ * @throws {EmptyKeyError} If key is empty
+ * @example
+ * ```javascript
+ * import { HMAC } from '@voltaire/crypto';
+ *
+ * const key = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+ * const message = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+ * const mac = HMAC.sha512(key, message);
+ * ```
+ */
+export function sha512Hmac(key, message) {
+	if (key.length === 0) {
+		throw new EmptyKeyError();
+	}
+
+	return /** @type {import('./HMACType.js').HMACType} */ (
+		hmac(sha512, key, message)
+	);
+}


### PR DESCRIPTION
## Summary
- Fixes #117
- Add HMAC module with sha256 and sha512 implementations
- HMAC now rejects empty keys with EmptyKeyError
- Prevents security issues from missing keys

## Test plan
- [x] Added tests for empty key rejection
- [x] Tests for single-byte keys (minimum valid)
- [x] Tests for empty messages (valid use case)
- [x] Tests for different keys/messages produce different outputs
- [x] Ran HMAC tests (15 tests passed)

🤖 Generated with [Claude Code](https://claude.ai/code)