### PR TITLE
fix: Validate Withdrawal index as uint64 per EIP-4895

### DIFF
--- a/src/primitives/WithdrawalIndex/WithdrawalIndex.test.ts
+++ b/src/primitives/WithdrawalIndex/WithdrawalIndex.test.ts
@@ -34,6 +34,23 @@ describe("WithdrawalIndex", () => {
 		it("rejects non-integer number", () => {
 			expect(() => WithdrawalIndex.from(1.5)).toThrow("safe integer");
 		});
+
+		it("accepts max uint64 value", () => {
+			const maxUint64 = 18446744073709551615n;
+			const idx = WithdrawalIndex.from(maxUint64);
+			expect(idx).toBe(maxUint64);
+		});
+
+		it("rejects value exceeding uint64 max", () => {
+			const overMax = 18446744073709551616n;
+			expect(() => WithdrawalIndex.from(overMax)).toThrow("exceeds uint64 max");
+		});
+
+		it("rejects large string value exceeding uint64", () => {
+			expect(() => WithdrawalIndex.from("18446744073709551616")).toThrow(
+				"exceeds uint64 max",
+			);
+		});
 	});
 
 	describe("toNumber", () => {

--- a/src/primitives/WithdrawalIndex/from.js
+++ b/src/primitives/WithdrawalIndex/from.js
@@ -1,11 +1,15 @@
+/** Maximum uint64 value (2^64 - 1) per EIP-4895 */
+const MAX_UINT64 = 18446744073709551615n;
+
 /**
  * Create WithdrawalIndex from number, bigint, or string
  *
  * @see https://voltaire.tevm.sh/primitives/withdrawal-index for WithdrawalIndex documentation
+ * @see https://eips.ethereum.org/EIPS/eip-4895 for EIP-4895 specification
  * @since 0.0.0
  * @param {number | bigint | string} value - Withdrawal index (number, bigint, or decimal/hex string)
  * @returns {import('./WithdrawalIndexType.js').WithdrawalIndexType} WithdrawalIndex value
- * @throws {Error} If value is negative or invalid
+ * @throws {Error} If value is negative, exceeds uint64 max, or invalid
  * @example
  * ```javascript
  * import * as WithdrawalIndex from './primitives/WithdrawalIndex/index.js';
@@ -33,6 +37,12 @@ export function from(value) {
 
 	if (bigintValue < 0n) {
 		throw new Error(`WithdrawalIndex value cannot be negative: ${bigintValue}`);
+	}
+
+	if (bigintValue > MAX_UINT64) {
+		throw new Error(
+			`WithdrawalIndex value exceeds uint64 max (${MAX_UINT64}): ${bigintValue}`,
+		);
 	}
 
 	return /** @type {import('./WithdrawalIndexType.js').WithdrawalIndexType} */ (


### PR DESCRIPTION
## Summary
- Fixes #128
- Withdrawal index validated as uint64 (0 to 2^64-1)
- Per EIP-4895 specification

## Test plan
- [x] Added tests for uint64 range validation
- [x] Ran Withdrawal tests

🤖 Generated with [Claude Code](https://claude.ai/code)