### PR TITLE
fix: Validate storage slot keys are bytes32

### DIFF
--- a/src/primitives/State/State.test.ts
+++ b/src/primitives/State/State.test.ts
@@ -136,6 +136,15 @@ describe("StorageKey.is", () => {
 		expect(StorageKey.is({ address: addr1, slot: "42" })).toBe(false);
 	});
 
+	it("returns false for negative slot", () => {
+		expect(StorageKey.is({ address: addr1, slot: -1n })).toBe(false);
+	});
+
+	it("returns false for slot exceeding bytes32", () => {
+		const tooBig = 2n ** 256n; // Exactly 2^256 is too big (max is 2^256 - 1)
+		expect(StorageKey.is({ address: addr1, slot: tooBig })).toBe(false);
+	});
+
 	it("returns false for array", () => {
 		expect(StorageKey.is([addr1, 0n])).toBe(false);
 	});
@@ -179,6 +188,55 @@ describe("StorageKey.create", () => {
 		const key2 = StorageKey.create(addr2, 2n);
 		expect(key1.address).not.toBe(key2.address);
 		expect(key1.slot).not.toBe(key2.slot);
+	});
+
+	it("throws on negative slot", () => {
+		expect(() => StorageKey.create(addr1, -1n)).toThrow(RangeError);
+		expect(() => StorageKey.create(addr1, -1n)).toThrow(
+			"Storage slot must be a non-negative value that fits in bytes32",
+		);
+	});
+
+	it("throws on slot exceeding bytes32", () => {
+		const tooBig = 2n ** 256n;
+		expect(() => StorageKey.create(addr1, tooBig)).toThrow(RangeError);
+	});
+
+	it("accepts max valid slot (2^256 - 1)", () => {
+		const maxSlot = 2n ** 256n - 1n;
+		const key = StorageKey.create(addr1, maxSlot);
+		expect(key.slot).toBe(maxSlot);
+	});
+});
+
+// ============================================================================
+// StorageKey.from Tests
+// ============================================================================
+
+describe("StorageKey.from", () => {
+	it("converts StorageKeyLike to StorageKey", () => {
+		const key = StorageKey.from({ address: addr1, slot: 42n });
+		expect(key.address).toBe(addr1);
+		expect(key.slot).toBe(42n);
+	});
+
+	it("throws on negative slot", () => {
+		expect(() => StorageKey.from({ address: addr1, slot: -1n })).toThrow(
+			RangeError,
+		);
+	});
+
+	it("throws on slot exceeding bytes32", () => {
+		const tooBig = 2n ** 256n;
+		expect(() => StorageKey.from({ address: addr1, slot: tooBig })).toThrow(
+			RangeError,
+		);
+	});
+
+	it("accepts max valid slot (2^256 - 1)", () => {
+		const maxSlot = 2n ** 256n - 1n;
+		const key = StorageKey.from({ address: addr1, slot: maxSlot });
+		expect(key.slot).toBe(maxSlot);
 	});
 });
 

--- a/src/primitives/State/create.js
+++ b/src/primitives/State/create.js
@@ -1,12 +1,15 @@
+/** Maximum value for a 256-bit storage slot (2^256 - 1) */
+const MAX_UINT256 = 2n ** 256n - 1n;
+
 /**
  * Create a new StorageKey
  *
  * @see https://voltaire.tevm.sh/primitives/state for State documentation
  * @since 0.0.0
  * @param {import('../Address/index.js').AddressType} address - Contract address
- * @param {bigint} slot - Storage slot number
+ * @param {bigint} slot - Storage slot number (must fit in bytes32)
  * @returns {import('./StorageKeyType.js').StorageKeyType} A new StorageKey
- * @throws {never}
+ * @throws {RangeError} If slot is negative or exceeds 256 bits
  * @example
  * ```javascript
  * import * as State from './primitives/State/index.js';
@@ -16,5 +19,10 @@
  * ```
  */
 export function create(address, slot) {
+	if (slot < 0n || slot > MAX_UINT256) {
+		throw new RangeError(
+			"Storage slot must be a non-negative value that fits in bytes32 (0 to 2^256-1)",
+		);
+	}
 	return { address, slot };
 }

--- a/src/primitives/State/from.js
+++ b/src/primitives/State/from.js
@@ -1,3 +1,6 @@
+/** Maximum value for a 256-bit storage slot (2^256 - 1) */
+const MAX_UINT256 = 2n ** 256n - 1n;
+
 /**
  * Convert StorageKeyLike to StorageKey
  *
@@ -5,7 +8,7 @@
  * @since 0.0.0
  * @param {import('./StorageKeyType.js').StorageKeyLike} value - Value to convert
  * @returns {import('./StorageKeyType.js').StorageKeyType} StorageKey
- * @throws {never}
+ * @throws {RangeError} If slot is negative or exceeds 256 bits
  * @example
  * ```javascript
  * import * as State from './primitives/State/index.js';
@@ -13,5 +16,10 @@
  * ```
  */
 export function from(value) {
+	if (value.slot < 0n || value.slot > MAX_UINT256) {
+		throw new RangeError(
+			"Storage slot must be a non-negative value that fits in bytes32 (0 to 2^256-1)",
+		);
+	}
 	return { address: value.address, slot: value.slot };
 }

--- a/src/primitives/State/is.js
+++ b/src/primitives/State/is.js
@@ -1,3 +1,6 @@
+/** Maximum value for a 256-bit storage slot (2^256 - 1) */
+const MAX_UINT256 = 2n ** 256n - 1n;
+
 /**
  * Type guard to check if a value is a valid StorageKey
  *
@@ -17,11 +20,14 @@
  */
 export function is(value) {
 	if (typeof value !== "object" || value === null) return false;
-	return (
-		"address" in value &&
-		value.address instanceof Uint8Array &&
-		value.address.length === 20 &&
-		"slot" in value &&
-		typeof value.slot === "bigint"
-	);
+	if (
+		!("address" in value) ||
+		!(value.address instanceof Uint8Array) ||
+		value.address.length !== 20
+	)
+		return false;
+	if (!("slot" in value) || typeof value.slot !== "bigint") return false;
+	// Validate slot fits in bytes32 (256 bits)
+	if (value.slot < 0n || value.slot > MAX_UINT256) return false;
+	return true;
 }


### PR DESCRIPTION
## Summary
- Fixes #131
- Storage slot keys must be exactly 32 bytes (256 bits, 0 to 2^256-1)
- Added validation for slot key range in `is()`, `create()`, and `from()` functions

## Test plan
- [x] Added tests for invalid slot key rejection (negative values)
- [x] Added tests for slots exceeding max uint256 (2^256)
- [x] Added tests verifying max valid slot (2^256 - 1) is accepted
- [x] Ran State tests: `pnpm vitest run src/primitives/State/State.test.ts` - 80 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)