### PR TITLE
fix: Validate RIPEMD160 output buffer size

### DIFF
--- a/src/crypto/hash_algorithms.zig
+++ b/src/crypto/hash_algorithms.zig
@@ -140,6 +140,46 @@ test "RIPEMD160 hashFixed function" {
     try std.testing.expectEqual(expected, result);
 }
 
+test "RIPEMD160 rejects undersized output buffer" {
+    const test_input = "abc";
+
+    // Buffer too small (19 bytes instead of 20)
+    var small_output: [19]u8 = undefined;
+    const result = RIPEMD160.hash(test_input, &small_output);
+    try std.testing.expectError(HashError.OutputBufferTooSmall, result);
+
+    // Zero-length buffer
+    var empty_output: [0]u8 = undefined;
+    const result2 = RIPEMD160.hash(test_input, &empty_output);
+    try std.testing.expectError(HashError.OutputBufferTooSmall, result2);
+
+    // Buffer exactly 20 bytes should succeed
+    var correct_output: [20]u8 = undefined;
+    try RIPEMD160.hash(test_input, &correct_output);
+
+    // Buffer larger than 20 bytes should also succeed
+    var large_output: [32]u8 = undefined;
+    try RIPEMD160.hash(test_input, &large_output);
+}
+
+test "SHA256 rejects undersized output buffer" {
+    const test_input = "hello";
+
+    // Buffer too small (31 bytes instead of 32)
+    var small_output: [31]u8 = undefined;
+    const result = SHA256.hash(test_input, &small_output);
+    try std.testing.expectError(HashError.OutputBufferTooSmall, result);
+
+    // Zero-length buffer
+    var empty_output: [0]u8 = undefined;
+    const result2 = SHA256.hash(test_input, &empty_output);
+    try std.testing.expectError(HashError.OutputBufferTooSmall, result2);
+
+    // Buffer exactly 32 bytes should succeed
+    var correct_output: [32]u8 = undefined;
+    try SHA256.hash(test_input, &correct_output);
+}
+
 /// BLAKE2F compression function
 /// EIP-152 compatible compression function for BLAKE2b
 pub const BLAKE2F = struct {


### PR DESCRIPTION
## Summary
- Fixes #135
- RIPEMD160 validates output buffer is at least 20 bytes
- Prevents buffer overflow

## Details
The validation logic was already present in `src/crypto/hash_algorithms.zig` (lines 98-101) but lacked test coverage. Added tests to verify:
- Undersized buffer (19 bytes) returns `HashError.OutputBufferTooSmall`
- Zero-length buffer returns `HashError.OutputBufferTooSmall`  
- Exact size buffer (20 bytes) succeeds
- Larger buffer (32 bytes) succeeds

Also added equivalent tests for SHA256 for consistency.

## Test plan
- [x] Added tests for undersized buffer rejection
- [x] Ran `zig build test` - all pass
- [x] Ran `pnpm test:run` - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)