### PR TITLE
docs: Clarify Bytes.trimLeft behavior for fixed-width contexts

### DIFF
--- a/src/primitives/Bytes/trimLeft.js
+++ b/src/primitives/Bytes/trimLeft.js
@@ -1,14 +1,27 @@
 /**
- * Trim leading zeros from Bytes
+ * Trim ALL leading zeros from Bytes
+ *
+ * Removes every leading zero byte until a non-zero byte is found.
+ * Returns an empty Uint8Array if input contains only zeros.
+ *
+ * **Warning**: This removes ALL leading zeros, including those that may be
+ * significant for fixed-width values (e.g., 32-byte hashes, addresses).
+ * For fixed-width contexts, use `padLeft` after trimming to restore length.
  *
  * @param {import('./BytesType.js').BytesType} bytes - Bytes to trim
- * @returns {import('./BytesType.js').BytesType} Trimmed bytes
+ * @returns {import('./BytesType.js').BytesType} Trimmed bytes (may be shorter than input)
  *
  * @example
  * ```javascript
  * import * as Bytes from './primitives/Bytes/index.js';
+ *
+ * // Basic trimming
  * Bytes.trimLeft(new Uint8Array([0x00, 0x00, 0x12, 0x34])); // Uint8Array([0x12, 0x34])
  * Bytes.trimLeft(new Uint8Array([0x00, 0x00, 0x00]));       // Uint8Array([])
+ *
+ * // Fixed-width restoration (e.g., 32-byte value)
+ * const trimmed = Bytes.trimLeft(bytes);
+ * const restored = Bytes.padLeft(trimmed, 32); // Restore to 32 bytes
  * ```
  */
 export function trimLeft(bytes) {

--- a/src/primitives/Bytes/trimLeft.test.ts
+++ b/src/primitives/Bytes/trimLeft.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { trimLeft } from "./trimLeft.js";
+import { padLeft } from "./padLeft.js";
 
 describe("Bytes.trimLeft", () => {
 	it("removes leading zeros", () => {
@@ -26,5 +27,36 @@ describe("Bytes.trimLeft", () => {
 		expect(trimLeft(new Uint8Array([0, 0x12, 0, 0x34]))).toEqual(
 			new Uint8Array([0x12, 0, 0x34]),
 		);
+	});
+
+	describe("fixed-width value handling", () => {
+		it("removes significant zeros from fixed-width values", () => {
+			// A 4-byte value representing 0x00000001 (value: 1)
+			const fixedWidth = new Uint8Array([0x00, 0x00, 0x00, 0x01]);
+			const trimmed = trimLeft(fixedWidth);
+			// trimLeft removes ALL leading zeros, changing length
+			expect(trimmed).toEqual(new Uint8Array([0x01]));
+			expect(trimmed.length).toBe(1); // Length reduced from 4 to 1
+		});
+
+		it("can restore fixed-width with padLeft after trimming", () => {
+			// Simulate round-trip: trim then pad back to original width
+			const original = new Uint8Array([0x00, 0x00, 0x00, 0x01]);
+			const trimmed = trimLeft(original);
+			const restored = padLeft(trimmed, 4);
+			expect(restored).toEqual(original);
+			expect(restored.length).toBe(4);
+		});
+
+		it("returns empty array when all zeros are trimmed", () => {
+			// 32-byte zero value (like a null hash)
+			const zeroHash = new Uint8Array(32).fill(0);
+			const trimmed = trimLeft(zeroHash);
+			expect(trimmed).toEqual(new Uint8Array([]));
+			expect(trimmed.length).toBe(0);
+			// Restore with padLeft if needed
+			const restored = padLeft(trimmed, 32);
+			expect(restored.length).toBe(32);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- Fixes #124
- Documents that trimLeft removes all leading zeros
- Added warning about fixed-width value handling

## Test plan
- [x] Added tests documenting behavior
- [x] Ran Bytes tests

🤖 Generated with [Claude Code](https://claude.ai/code)