### PR TITLE
fix: Validate maxPriorityFeePerGas <= maxFeePerGas

### DIFF
--- a/src/primitives/Transaction/EIP1559/EIP1559.js
+++ b/src/primitives/Transaction/EIP1559/EIP1559.js
@@ -7,6 +7,7 @@ import {
 	recoverPublicKey as secp256k1RecoverPublicKey,
 	verify as secp256k1Verify,
 } from "../../../crypto/Secp256k1/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
 import { encode as rlpEncode } from "../../Rlp/encode.js";
 import { Type } from "../types.js";
 import { deserialize } from "./deserialize.js";
@@ -52,6 +53,22 @@ export {
  * @type {TransactionEIP1559Constructor}
  */
 export function TransactionEIP1559(tx) {
+	// Validate maxPriorityFeePerGas <= maxFeePerGas
+	if (tx.maxPriorityFeePerGas > tx.maxFeePerGas) {
+		throw new InvalidRangeError(
+			"Max priority fee per gas cannot exceed max fee per gas",
+			{
+				code: "MAX_PRIORITY_FEE_TOO_HIGH",
+				value: tx.maxPriorityFeePerGas,
+				expected: `Max priority fee <= ${tx.maxFeePerGas}`,
+				context: {
+					maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+					maxFeePerGas: tx.maxFeePerGas,
+				},
+				docsPath: "/primitives/transaction/validate-gas-price#error-handling",
+			},
+		);
+	}
 	return /** @type {BrandedTransactionEIP1559} */ ({
 		type: Type.EIP1559,
 		chainId: tx.chainId,

--- a/src/primitives/Transaction/EIP1559/TransactionEIP1559.test.ts
+++ b/src/primitives/Transaction/EIP1559/TransactionEIP1559.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import * as Secp256k1 from "../../../crypto/Secp256k1/index.js";
 import { PrivateKey } from "../../../crypto/Secp256k1/index.js";
 import { Address } from "../../Address/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
 import { Type } from "../types.js";
 import { TransactionEIP1559 } from "./index.js";
 
@@ -127,6 +128,62 @@ describe("TransactionEIP1559", () => {
 			});
 
 			expect(tx.data.length).toBe(10000);
+		});
+
+		it("rejects maxPriorityFeePerGas > maxFeePerGas", () => {
+			expect(() =>
+				TransactionEIP1559({
+					chainId: 1n,
+					nonce: 0n,
+					maxPriorityFeePerGas: 30000000000n,
+					maxFeePerGas: 20000000000n,
+					gasLimit: 21000n,
+					to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+					value: 0n,
+					data: new Uint8Array(),
+					accessList: [],
+					yParity: 0,
+					r: new Uint8Array(32).fill(1),
+					s: new Uint8Array(32).fill(2),
+				}),
+			).toThrow(InvalidRangeError);
+		});
+
+		it("rejects maxPriorityFeePerGas > maxFeePerGas with correct error message", () => {
+			expect(() =>
+				TransactionEIP1559({
+					chainId: 1n,
+					nonce: 0n,
+					maxPriorityFeePerGas: 30000000000n,
+					maxFeePerGas: 20000000000n,
+					gasLimit: 21000n,
+					to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+					value: 0n,
+					data: new Uint8Array(),
+					accessList: [],
+					yParity: 0,
+					r: new Uint8Array(32).fill(1),
+					s: new Uint8Array(32).fill(2),
+				}),
+			).toThrow("Max priority fee per gas cannot exceed max fee per gas");
+		});
+
+		it("accepts maxPriorityFeePerGas equal to maxFeePerGas", () => {
+			const tx = TransactionEIP1559({
+				chainId: 1n,
+				nonce: 0n,
+				maxPriorityFeePerGas: 20000000000n,
+				maxFeePerGas: 20000000000n,
+				gasLimit: 21000n,
+				to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+				value: 0n,
+				data: new Uint8Array(),
+				accessList: [],
+				yParity: 0,
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(2),
+			});
+			expect(tx.maxPriorityFeePerGas).toBe(tx.maxFeePerGas);
 		});
 	});
 

--- a/src/primitives/Transaction/EIP4844/TransactionEIP4844.js
+++ b/src/primitives/Transaction/EIP4844/TransactionEIP4844.js
@@ -7,6 +7,7 @@ import {
 	recoverPublicKey as secp256k1RecoverPublicKey,
 	verify as secp256k1Verify,
 } from "../../../crypto/Secp256k1/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
 import { encode as rlpEncode } from "../../Rlp/encode.js";
 import { Type } from "../types.js";
 import { deserialize } from "./deserialize.js";
@@ -54,6 +55,22 @@ export {
  * @type {TransactionEIP4844Constructor}
  */
 export function TransactionEIP4844(tx) {
+	// Validate maxPriorityFeePerGas <= maxFeePerGas
+	if (tx.maxPriorityFeePerGas > tx.maxFeePerGas) {
+		throw new InvalidRangeError(
+			"Max priority fee per gas cannot exceed max fee per gas",
+			{
+				code: "MAX_PRIORITY_FEE_TOO_HIGH",
+				value: tx.maxPriorityFeePerGas,
+				expected: `Max priority fee <= ${tx.maxFeePerGas}`,
+				context: {
+					maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+					maxFeePerGas: tx.maxFeePerGas,
+				},
+				docsPath: "/primitives/transaction/validate-gas-price#error-handling",
+			},
+		);
+	}
 	return /** @type {TransactionEIP4844Type} */ ({
 		type: Type.EIP4844,
 		chainId: tx.chainId,

--- a/src/primitives/Transaction/EIP4844/TransactionEIP4844.test.ts
+++ b/src/primitives/Transaction/EIP4844/TransactionEIP4844.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import { Address } from "../../Address/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
+import { Hash } from "../../Hash/index.js";
+import { TransactionEIP4844 } from "./TransactionEIP4844.js";
+
+describe("TransactionEIP4844 constructor", () => {
+	it("creates valid transaction", () => {
+		const tx = TransactionEIP4844({
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 1000000000n,
+			maxFeePerGas: 20000000000n,
+			gasLimit: 100000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			maxFeePerBlobGas: 2000000000n,
+			blobVersionedHashes: [
+				Hash(
+					"0x0100000000000000000000000000000000000000000000000000000000000001",
+				),
+			],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		});
+		expect(tx.chainId).toBe(1n);
+	});
+
+	it("rejects maxPriorityFeePerGas > maxFeePerGas", () => {
+		expect(() =>
+			TransactionEIP4844({
+				chainId: 1n,
+				nonce: 0n,
+				maxPriorityFeePerGas: 30000000000n,
+				maxFeePerGas: 20000000000n,
+				gasLimit: 100000n,
+				to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+				value: 0n,
+				data: new Uint8Array(),
+				accessList: [],
+				maxFeePerBlobGas: 2000000000n,
+				blobVersionedHashes: [
+					Hash(
+						"0x0100000000000000000000000000000000000000000000000000000000000001",
+					),
+				],
+				yParity: 0,
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(2),
+			}),
+		).toThrow(InvalidRangeError);
+	});
+
+	it("rejects maxPriorityFeePerGas > maxFeePerGas with correct error message", () => {
+		expect(() =>
+			TransactionEIP4844({
+				chainId: 1n,
+				nonce: 0n,
+				maxPriorityFeePerGas: 30000000000n,
+				maxFeePerGas: 20000000000n,
+				gasLimit: 100000n,
+				to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+				value: 0n,
+				data: new Uint8Array(),
+				accessList: [],
+				maxFeePerBlobGas: 2000000000n,
+				blobVersionedHashes: [
+					Hash(
+						"0x0100000000000000000000000000000000000000000000000000000000000001",
+					),
+				],
+				yParity: 0,
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(2),
+			}),
+		).toThrow("Max priority fee per gas cannot exceed max fee per gas");
+	});
+
+	it("accepts maxPriorityFeePerGas equal to maxFeePerGas", () => {
+		const tx = TransactionEIP4844({
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 20000000000n,
+			maxFeePerGas: 20000000000n,
+			gasLimit: 100000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			maxFeePerBlobGas: 2000000000n,
+			blobVersionedHashes: [
+				Hash(
+					"0x0100000000000000000000000000000000000000000000000000000000000001",
+				),
+			],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		});
+		expect(tx.maxPriorityFeePerGas).toBe(tx.maxFeePerGas);
+	});
+});

--- a/src/primitives/Transaction/EIP7702/TransactionEIP7702.js
+++ b/src/primitives/Transaction/EIP7702/TransactionEIP7702.js
@@ -7,6 +7,7 @@ import {
 	recoverPublicKey as secp256k1RecoverPublicKey,
 	verify as secp256k1Verify,
 } from "../../../crypto/Secp256k1/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
 import { encode as rlpEncode } from "../../Rlp/encode.js";
 import { Type } from "../types.js";
 import { deserialize } from "./deserialize.js";
@@ -52,6 +53,22 @@ export {
  * @type {TransactionEIP7702Constructor}
  */
 export function TransactionEIP7702(tx) {
+	// Validate maxPriorityFeePerGas <= maxFeePerGas
+	if (tx.maxPriorityFeePerGas > tx.maxFeePerGas) {
+		throw new InvalidRangeError(
+			"Max priority fee per gas cannot exceed max fee per gas",
+			{
+				code: "MAX_PRIORITY_FEE_TOO_HIGH",
+				value: tx.maxPriorityFeePerGas,
+				expected: `Max priority fee <= ${tx.maxFeePerGas}`,
+				context: {
+					maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+					maxFeePerGas: tx.maxFeePerGas,
+				},
+				docsPath: "/primitives/transaction/validate-gas-price#error-handling",
+			},
+		);
+	}
 	return /** @type {TransactionEIP7702Type} */ ({
 		type: Type.EIP7702,
 		chainId: tx.chainId,

--- a/src/primitives/Transaction/EIP7702/TransactionEIP7702.test.ts
+++ b/src/primitives/Transaction/EIP7702/TransactionEIP7702.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { Address } from "../../Address/index.js";
+import { InvalidRangeError } from "../../errors/index.js";
+import { TransactionEIP7702 } from "./TransactionEIP7702.js";
+
+describe("TransactionEIP7702 constructor", () => {
+	it("creates valid transaction", () => {
+		const tx = TransactionEIP7702({
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 1000000000n,
+			maxFeePerGas: 20000000000n,
+			gasLimit: 100000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			authorizationList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		});
+		expect(tx.chainId).toBe(1n);
+	});
+
+	it("rejects maxPriorityFeePerGas > maxFeePerGas", () => {
+		expect(() =>
+			TransactionEIP7702({
+				chainId: 1n,
+				nonce: 0n,
+				maxPriorityFeePerGas: 30000000000n,
+				maxFeePerGas: 20000000000n,
+				gasLimit: 100000n,
+				to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+				value: 0n,
+				data: new Uint8Array(),
+				accessList: [],
+				authorizationList: [],
+				yParity: 0,
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(2),
+			}),
+		).toThrow(InvalidRangeError);
+	});
+
+	it("rejects maxPriorityFeePerGas > maxFeePerGas with correct error message", () => {
+		expect(() =>
+			TransactionEIP7702({
+				chainId: 1n,
+				nonce: 0n,
+				maxPriorityFeePerGas: 30000000000n,
+				maxFeePerGas: 20000000000n,
+				gasLimit: 100000n,
+				to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+				value: 0n,
+				data: new Uint8Array(),
+				accessList: [],
+				authorizationList: [],
+				yParity: 0,
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(2),
+			}),
+		).toThrow("Max priority fee per gas cannot exceed max fee per gas");
+	});
+
+	it("accepts maxPriorityFeePerGas equal to maxFeePerGas", () => {
+		const tx = TransactionEIP7702({
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 20000000000n,
+			maxFeePerGas: 20000000000n,
+			gasLimit: 100000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			authorizationList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		});
+		expect(tx.maxPriorityFeePerGas).toBe(tx.maxFeePerGas);
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #107
- EIP-1559/4844/7702 transaction constructors now validate fee configuration
- Throws `InvalidRangeError` with code `MAX_PRIORITY_FEE_TOO_HIGH` if `maxPriorityFeePerGas > maxFeePerGas`

## Test plan
- [x] Added constructor validation tests for EIP-1559 transactions
- [x] Added constructor validation tests for EIP-4844 transactions  
- [x] Added constructor validation tests for EIP-7702 transactions
- [x] Verified existing `validateGasPrice` utility tests still pass
- [x] All Transaction tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)