### PR TITLE
fix: Prevent negative values in getEffectiveGasPrice

### DIFF
--- a/src/primitives/Transaction/EIP1559/getEffectiveGasPrice.js
+++ b/src/primitives/Transaction/EIP1559/getEffectiveGasPrice.js
@@ -16,7 +16,12 @@
 export function getEffectiveGasPrice(tx, baseFee) {
 	const maxPriorityFee = tx.maxPriorityFeePerGas;
 	const maxFee = tx.maxFeePerGas;
-	const effectivePriorityFee =
-		maxFee - baseFee < maxPriorityFee ? maxFee - baseFee : maxPriorityFee;
-	return baseFee + effectivePriorityFee;
+	// EIP-1559: effectiveGasPrice = min(maxFeePerGas, baseFee + maxPriorityFeePerGas)
+	// When baseFee > maxFee, clamp to maxFee (never negative)
+	if (baseFee >= maxFee) {
+		return maxFee;
+	}
+	const priorityFee =
+		maxPriorityFee < maxFee - baseFee ? maxPriorityFee : maxFee - baseFee;
+	return baseFee + priorityFee;
 }

--- a/src/primitives/Transaction/EIP1559/getEffectiveGasPrice.test.ts
+++ b/src/primitives/Transaction/EIP1559/getEffectiveGasPrice.test.ts
@@ -221,4 +221,84 @@ describe("TransactionEIP1559.getEffectiveGasPrice", () => {
 
 		expect(effectivePrice).toBe(0n);
 	});
+
+	it("returns maxFee when baseFee exceeds maxFee (prevents negative)", () => {
+		const tx: TransactionEIP1559Type = {
+			__brand: "TransactionEIP1559",
+			type: Type.EIP1559,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 2000000000n,
+			maxFeePerGas: 10000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 1000000000000000000n,
+			data: new Uint8Array(),
+			accessList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		};
+
+		// baseFee (50 gwei) > maxFee (10 gwei)
+		const baseFee = 50000000000n;
+		const effectivePrice = TransactionEIP1559.getEffectiveGasPrice(tx, baseFee);
+
+		// Should return maxFee, not a negative value
+		expect(effectivePrice).toBe(10000000000n);
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+	});
+
+	it("returns maxFee when baseFee equals maxFee exactly", () => {
+		const tx: TransactionEIP1559Type = {
+			__brand: "TransactionEIP1559",
+			type: Type.EIP1559,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 2000000000n,
+			maxFeePerGas: 20000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 1000000000000000000n,
+			data: new Uint8Array(),
+			accessList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		};
+
+		// baseFee exactly equals maxFee
+		const baseFee = 20000000000n;
+		const effectivePrice = TransactionEIP1559.getEffectiveGasPrice(tx, baseFee);
+
+		// Should return maxFee (no room for priority fee)
+		expect(effectivePrice).toBe(20000000000n);
+	});
+
+	it("never returns negative even with extreme baseFee", () => {
+		const tx: TransactionEIP1559Type = {
+			__brand: "TransactionEIP1559",
+			type: Type.EIP1559,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 1000000000n,
+			maxFeePerGas: 5000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 1000000000000000000n,
+			data: new Uint8Array(),
+			accessList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		};
+
+		// baseFee is 100x the maxFee
+		const baseFee = 500000000000n;
+		const effectivePrice = TransactionEIP1559.getEffectiveGasPrice(tx, baseFee);
+
+		// Must never be negative
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+		expect(effectivePrice).toBe(5000000000n);
+	});
 });

--- a/src/primitives/Transaction/EIP4844/getEffectiveGasPrice.js
+++ b/src/primitives/Transaction/EIP4844/getEffectiveGasPrice.js
@@ -16,7 +16,12 @@
 export function getEffectiveGasPrice(tx, baseFee) {
 	const maxPriorityFee = tx.maxPriorityFeePerGas;
 	const maxFee = tx.maxFeePerGas;
-	const effectivePriorityFee =
-		maxFee - baseFee < maxPriorityFee ? maxFee - baseFee : maxPriorityFee;
-	return baseFee + effectivePriorityFee;
+	// EIP-1559: effectiveGasPrice = min(maxFeePerGas, baseFee + maxPriorityFeePerGas)
+	// When baseFee > maxFee, clamp to maxFee (never negative)
+	if (baseFee >= maxFee) {
+		return maxFee;
+	}
+	const priorityFee =
+		maxPriorityFee < maxFee - baseFee ? maxPriorityFee : maxFee - baseFee;
+	return baseFee + priorityFee;
 }

--- a/src/primitives/Transaction/EIP4844/getEffectiveGasPrice.test.ts
+++ b/src/primitives/Transaction/EIP4844/getEffectiveGasPrice.test.ts
@@ -134,4 +134,62 @@ describe("TransactionEIP4844.getEffectiveGasPrice", () => {
 
 		expect(effectivePrice).toBe(20000000000n);
 	});
+
+	it("returns maxFee when baseFee exceeds maxFee (prevents negative)", () => {
+		const tx: TransactionEIP4844Type = {
+			__brand: "TransactionEIP4844",
+			type: Type.EIP4844,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 2000000000n,
+			maxFeePerGas: 10000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			maxFeePerBlobGas: 1000000000n,
+			blobVersionedHashes: [new Uint8Array(32).fill(1)],
+			yParity: 0,
+			r: new Uint8Array(32),
+			s: new Uint8Array(32),
+		};
+
+		// baseFee (50 gwei) > maxFee (10 gwei)
+		const baseFee = 50000000000n;
+		const effectivePrice = TransactionEIP4844.getEffectiveGasPrice(tx, baseFee);
+
+		// Should return maxFee, not a negative value
+		expect(effectivePrice).toBe(10000000000n);
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+	});
+
+	it("never returns negative even with extreme baseFee", () => {
+		const tx: TransactionEIP4844Type = {
+			__brand: "TransactionEIP4844",
+			type: Type.EIP4844,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 1000000000n,
+			maxFeePerGas: 5000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 0n,
+			data: new Uint8Array(),
+			accessList: [],
+			maxFeePerBlobGas: 1000000000n,
+			blobVersionedHashes: [new Uint8Array(32).fill(1)],
+			yParity: 0,
+			r: new Uint8Array(32),
+			s: new Uint8Array(32),
+		};
+
+		// baseFee is 100x the maxFee
+		const baseFee = 500000000000n;
+		const effectivePrice = TransactionEIP4844.getEffectiveGasPrice(tx, baseFee);
+
+		// Must never be negative
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+		expect(effectivePrice).toBe(5000000000n);
+	});
 });

--- a/src/primitives/Transaction/EIP7702/getEffectiveGasPrice.js
+++ b/src/primitives/Transaction/EIP7702/getEffectiveGasPrice.js
@@ -16,7 +16,12 @@
 export function getEffectiveGasPrice(tx, baseFee) {
 	const maxPriorityFee = tx.maxPriorityFeePerGas;
 	const maxFee = tx.maxFeePerGas;
-	const effectivePriorityFee =
-		maxFee - baseFee < maxPriorityFee ? maxFee - baseFee : maxPriorityFee;
-	return baseFee + effectivePriorityFee;
+	// EIP-1559: effectiveGasPrice = min(maxFeePerGas, baseFee + maxPriorityFeePerGas)
+	// When baseFee > maxFee, clamp to maxFee (never negative)
+	if (baseFee >= maxFee) {
+		return maxFee;
+	}
+	const priorityFee =
+		maxPriorityFee < maxFee - baseFee ? maxPriorityFee : maxFee - baseFee;
+	return baseFee + priorityFee;
 }

--- a/src/primitives/Transaction/EIP7702/getEffectiveGasPrice.test.ts
+++ b/src/primitives/Transaction/EIP7702/getEffectiveGasPrice.test.ts
@@ -238,4 +238,60 @@ describe("TransactionEIP7702.getEffectiveGasPrice", () => {
 
 		expect(effectivePrice).toBe(22000000000n);
 	});
+
+	it("returns maxFee when baseFee exceeds maxFee (prevents negative)", () => {
+		const tx: TransactionEIP7702Type = {
+			__brand: "TransactionEIP7702",
+			type: Type.EIP7702,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 2000000000n,
+			maxFeePerGas: 10000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 1000000000000000000n,
+			data: new Uint8Array(),
+			accessList: [],
+			authorizationList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		};
+
+		// baseFee (50 gwei) > maxFee (10 gwei)
+		const baseFee = 50000000000n;
+		const effectivePrice = TransactionEIP7702.getEffectiveGasPrice(tx, baseFee);
+
+		// Should return maxFee, not a negative value
+		expect(effectivePrice).toBe(10000000000n);
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+	});
+
+	it("never returns negative even with extreme baseFee", () => {
+		const tx: TransactionEIP7702Type = {
+			__brand: "TransactionEIP7702",
+			type: Type.EIP7702,
+			chainId: 1n,
+			nonce: 0n,
+			maxPriorityFeePerGas: 1000000000n,
+			maxFeePerGas: 5000000000n,
+			gasLimit: 21000n,
+			to: Address("0x742d35cc6634c0532925a3b844bc9e7595f0beb0"),
+			value: 1000000000000000000n,
+			data: new Uint8Array(),
+			accessList: [],
+			authorizationList: [],
+			yParity: 0,
+			r: new Uint8Array(32).fill(1),
+			s: new Uint8Array(32).fill(2),
+		};
+
+		// baseFee is 100x the maxFee
+		const baseFee = 500000000000n;
+		const effectivePrice = TransactionEIP7702.getEffectiveGasPrice(tx, baseFee);
+
+		// Must never be negative
+		expect(effectivePrice).toBeGreaterThanOrEqual(0n);
+		expect(effectivePrice).toBe(5000000000n);
+	});
 });


### PR DESCRIPTION
## Summary
- Fixes #78
- `getEffectiveGasPrice` no longer returns negative values
- Properly handles `maxFeePerGas < baseFee` case by returning `maxFeePerGas`
- Fixed all three EIP types: EIP-1559, EIP-4844, and EIP-7702

## Changes
When `baseFee >= maxFeePerGas`, the function now immediately returns `maxFeePerGas` instead of computing potentially negative intermediate values. This is correct per EIP-1559 semantics: `effectiveGasPrice = min(maxFeePerGas, baseFee + maxPriorityFeePerGas)`.

## Test plan
- [x] Added edge case tests for baseFee > maxFeePerGas
- [x] Added tests for baseFee == maxFeePerGas  
- [x] Added tests verifying result is never negative with extreme baseFee
- [x] Ran Transaction tests - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)