### PR TITLE
fix: Add EIP-55 all-caps and all-lowercase test vectors

### DIFF
--- a/src/primitives/Address/isValidChecksum.test.ts
+++ b/src/primitives/Address/isValidChecksum.test.ts
@@ -4,28 +4,28 @@ import { IsValidChecksum } from "./isValidChecksum.js";
 
 describe("isValidChecksum", () => {
 	describe("valid checksummed addresses", () => {
-		it("validates EIP-55 test vector 1", () => {
+		it("validates EIP-55 test vector 1 (normal)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
 			expect(
 				isValidChecksum("0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"),
 			).toBe(true);
 		});
 
-		it("validates EIP-55 test vector 2", () => {
+		it("validates EIP-55 test vector 2 (normal)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
 			expect(
 				isValidChecksum("0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"),
 			).toBe(true);
 		});
 
-		it("validates EIP-55 test vector 3", () => {
+		it("validates EIP-55 test vector 3 (normal)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
 			expect(
 				isValidChecksum("0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB"),
 			).toBe(true);
 		});
 
-		it("validates EIP-55 test vector 4", () => {
+		it("validates EIP-55 test vector 4 (normal)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
 			expect(
 				isValidChecksum("0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb"),
@@ -37,6 +37,40 @@ describe("isValidChecksum", () => {
 			expect(isValidChecksum("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed")).toBe(
 				true,
 			);
+		});
+	});
+
+	describe("EIP-55 official all-caps test vectors", () => {
+		// These addresses happen to have checksums that result in all uppercase letters
+		it("validates EIP-55 all-caps test vector 1", () => {
+			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			expect(
+				isValidChecksum("0x52908400098527886E0F7030069857D2E4169EE7"),
+			).toBe(true);
+		});
+
+		it("validates EIP-55 all-caps test vector 2", () => {
+			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			expect(
+				isValidChecksum("0x8617E340B3D01FA5F11F306F4090FD50E238070D"),
+			).toBe(true);
+		});
+	});
+
+	describe("EIP-55 official all-lowercase test vectors", () => {
+		// These addresses happen to have checksums that result in all lowercase letters
+		it("validates EIP-55 all-lower test vector 1", () => {
+			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			expect(
+				isValidChecksum("0xde709f2102306220921060314715629080e2fb77"),
+			).toBe(true);
+		});
+
+		it("validates EIP-55 all-lower test vector 2", () => {
+			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			expect(
+				isValidChecksum("0x27b1fdb04752bbc536007a920d24acb045561c26"),
+			).toBe(true);
 		});
 	});
 
@@ -73,46 +107,54 @@ describe("isValidChecksum", () => {
 		});
 	});
 
-	describe("all lowercase", () => {
-		it("rejects all lowercase (doesn't match checksum)", () => {
+	describe("incorrectly cased all-lowercase (checksum should be mixed-case)", () => {
+		// These addresses have checksums that require mixed case, so all-lowercase is invalid
+		it("rejects all lowercase when checksum requires mixed case", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// This is the lowercase form of test vector 1, but checksum requires mixed case
 			expect(
 				isValidChecksum("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed"),
 			).toBe(false);
 		});
 
-		it("rejects another all lowercase address", () => {
+		it("rejects another incorrectly lowercased address", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// This address checksum requires mixed case, not all lowercase
 			expect(
 				isValidChecksum("0x742d35cc6634c0532925a3b844bc9e7595f251e3"),
 			).toBe(false);
 		});
 
-		it("accepts zero address as lowercase (special case)", () => {
+		it("accepts zero address (no alpha chars to checksum)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// Zero address has no alpha chars, so it's always valid
 			expect(
 				isValidChecksum("0x0000000000000000000000000000000000000000"),
 			).toBe(true);
 		});
 	});
 
-	describe("all uppercase", () => {
-		it("rejects all uppercase (doesn't match checksum)", () => {
+	describe("incorrectly cased all-uppercase (checksum should be mixed-case)", () => {
+		// These addresses have checksums that require mixed case, so all-uppercase is invalid
+		it("rejects all uppercase when checksum requires mixed case", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// This is the uppercase form of test vector 1, but checksum requires mixed case
 			expect(
 				isValidChecksum("0x5AAEB6053F3E94C9B9A09F33669435E7EF1BEAED"),
 			).toBe(false);
 		});
 
-		it("rejects another all uppercase address", () => {
+		it("rejects another incorrectly uppercased address", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// This address checksum requires mixed case, not all uppercase
 			expect(
 				isValidChecksum("0x742D35CC6634C0532925A3B844BC9E7595F251E3"),
 			).toBe(false);
 		});
 
-		it("rejects max address as uppercase", () => {
+		it("rejects max address as uppercase (checksum requires mixed case)", () => {
 			const isValidChecksum = IsValidChecksum({ keccak256: hash });
+			// Max address (all f's) checksum is NOT all uppercase
 			expect(
 				isValidChecksum("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"),
 			).toBe(false);


### PR DESCRIPTION
## Summary
- Fixes #147
- Added official EIP-55 test vectors for addresses with all-caps checksums (`0x52908400...`, `0x8617E340...`)
- Added official EIP-55 test vectors for addresses with all-lowercase checksums (`0xde709f21...`, `0x27b1fdb0...`)
- Clarified existing test descriptions to distinguish between "legitimate" all-case addresses and "incorrectly cased" addresses

## Test plan
- [x] All 27 isValidChecksum tests pass
- [x] All Address tests pass (22122 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)