### PR TITLE
fix: Support EIP-712 fixed-size arrays

### DIFF
--- a/src/crypto/EIP712/encodeValue.js
+++ b/src/crypto/EIP712/encodeValue.js
@@ -29,8 +29,10 @@ export function EncodeValue({ keccak256, hashStruct }) {
 		const result = new Uint8Array(32);
 
 		// array types (hash the array encoding) - CHECK BEFORE uint/int to avoid matching "uint256[]"
-		if (type.endsWith("[]")) {
-			const baseType = type.slice(0, -2);
+		// Handle both dynamic arrays (uint256[]) and fixed-size arrays (uint256[3])
+		const arrayMatch = type.match(/^(.+)\[(\d*)\]$/);
+		if (arrayMatch) {
+			const baseType = /** @type {string} */ (arrayMatch[1]);
 			const arr = /** @type {import('./EIP712Type.js').MessageValue[]} */ (
 				value
 			);

--- a/src/primitives/Domain/encodeValue.js
+++ b/src/primitives/Domain/encodeValue.js
@@ -26,9 +26,10 @@ export function encodeValue(type, value, types, crypto) {
 		return encodeStringOrBytes(type, value, crypto);
 	}
 
-	// Handle array types
-	if (type.endsWith("[]")) {
-		const baseType = type.slice(0, -2);
+	// Handle array types - both dynamic (uint256[]) and fixed-size (uint256[3])
+	const arrayMatch = type.match(/^(.+)\[(\d*)\]$/);
+	if (arrayMatch) {
+		const baseType = /** @type {string} */ (arrayMatch[1]);
 		if (!Array.isArray(value)) {
 			throw new InvalidEIP712ValueError(`Expected array for type ${type}`, {
 				value,


### PR DESCRIPTION
## Summary
- Fixes #64
- EIP-712 now supports fixed-size arrays like uint256[3] and bytes32[10]
- Arrays encoded correctly per EIP-712 spec (hash of concatenated encoded elements)

## Test plan
- [x] Added tests for fixed-size uint256[3] arrays
- [x] Added tests for fixed-size bytes32[10] arrays
- [x] Added test verifying fixed and dynamic arrays produce equivalent hashes
- [x] Added integration tests with full typed data hashing
- [x] All 69 EIP712 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)