### PR TITLE
fix: Expand tuple types in ABI.getSignature()

### DIFF
--- a/src/primitives/Abi/abi.test.ts
+++ b/src/primitives/Abi/abi.test.ts
@@ -69,7 +69,7 @@ describe("Abi.Function.getSignature", () => {
 			outputs: [],
 		} as const satisfies AbiFunction;
 
-		expect(Abi.Function.getSignature(func)).toBe("swap(tuple)");
+		expect(Abi.Function.getSignature(func)).toBe("swap((address,uint256))");
 	});
 });
 

--- a/src/primitives/Abi/error/Error.test.ts
+++ b/src/primitives/Abi/error/Error.test.ts
@@ -169,7 +169,7 @@ describe("Error namespace", () => {
 		} as const;
 
 		const signature = Error.getSignature(error);
-		expect(signature).toBe("TupleError(tuple)");
+		expect(signature).toBe("TupleError((address,uint256))");
 	});
 
 	it("works with array parameter", () => {

--- a/src/primitives/Abi/error/getSignature.js
+++ b/src/primitives/Abi/error/getSignature.js
@@ -1,3 +1,5 @@
+import { formatCanonicalType } from "../formatCanonicalType.js";
+
 /**
  * Get the signature string for an error (e.g., "MyError(uint256,address)")
  *
@@ -13,6 +15,6 @@
  * ```
  */
 export function getSignature(error) {
-	const inputs = error.inputs.map((p) => p.type).join(",");
+	const inputs = error.inputs.map((p) => formatCanonicalType(p)).join(",");
 	return `${error.name}(${inputs})`;
 }

--- a/src/primitives/Abi/error/getSignature.test.ts
+++ b/src/primitives/Abi/error/getSignature.test.ts
@@ -137,7 +137,7 @@ describe("getSignature", () => {
 		} as const;
 
 		const signature = getSignature(error);
-		expect(signature).toBe("InvalidTuple(tuple)");
+		expect(signature).toBe("InvalidTuple((address,uint256))");
 	});
 
 	it("generates signature with nested tuple parameter", () => {
@@ -164,7 +164,7 @@ describe("getSignature", () => {
 		} as const;
 
 		const signature = getSignature(error);
-		expect(signature).toBe("ComplexError(tuple)");
+		expect(signature).toBe("ComplexError((address,(uint256,uint256)))");
 	});
 
 	it("generates signature with mixed parameter types", () => {
@@ -261,7 +261,7 @@ describe("getSignature", () => {
 		} as const;
 
 		const signature = getSignature(error);
-		expect(signature).toBe("BatchError(tuple[])");
+		expect(signature).toBe("BatchError((uint256,string)[])");
 	});
 
 	it("handles error names with underscores", () => {

--- a/src/primitives/Abi/event.test.ts
+++ b/src/primitives/Abi/event.test.ts
@@ -69,7 +69,7 @@ describe("Abi.Event.getSignature", () => {
 				},
 			],
 		};
-		expect(Abi.Event.getSignature(event)).toBe("DataUpdate(tuple)");
+		expect(Abi.Event.getSignature(event)).toBe("DataUpdate((address,uint256))");
 	});
 
 	it("generates signature with array", () => {

--- a/src/primitives/Abi/event/getSignature.js
+++ b/src/primitives/Abi/event/getSignature.js
@@ -1,3 +1,5 @@
+import { formatCanonicalType } from "../formatCanonicalType.js";
+
 /**
  * Get event signature string (e.g., "Transfer(address,address,uint256)")
  *
@@ -11,6 +13,6 @@
  * ```
  */
 export function getSignature(event) {
-	const inputs = event.inputs.map((p) => p.type).join(",");
+	const inputs = event.inputs.map((p) => formatCanonicalType(p)).join(",");
 	return `${event.name}(${inputs})`;
 }

--- a/src/primitives/Abi/event/getSignature.test.ts
+++ b/src/primitives/Abi/event/getSignature.test.ts
@@ -95,7 +95,7 @@ describe("getSignature", () => {
 			],
 		};
 
-		expect(getSignature(event)).toBe("TupleEvent(tuple)");
+		expect(getSignature(event)).toBe("TupleEvent((address,uint256))");
 	});
 
 	it("handles fixed-size arrays", () => {

--- a/src/primitives/Abi/formatCanonicalType.js
+++ b/src/primitives/Abi/formatCanonicalType.js
@@ -1,0 +1,55 @@
+/**
+ * Format a parameter type to its canonical form for signature generation.
+ * Expands tuple types to their component types, e.g., "tuple" -> "(uint256,address)"
+ *
+ * @param {import('./Parameter.js').Parameter} param - ABI parameter
+ * @returns {string} Canonical type string
+ *
+ * @example
+ * ```typescript
+ * // Simple type
+ * formatCanonicalType({ type: "address", name: "to" });
+ * // "address"
+ *
+ * // Tuple type
+ * formatCanonicalType({
+ *   type: "tuple",
+ *   name: "data",
+ *   components: [
+ *     { type: "address", name: "addr" },
+ *     { type: "uint256", name: "value" }
+ *   ]
+ * });
+ * // "(address,uint256)"
+ *
+ * // Tuple array
+ * formatCanonicalType({
+ *   type: "tuple[]",
+ *   name: "items",
+ *   components: [
+ *     { type: "address", name: "addr" },
+ *     { type: "uint256", name: "value" }
+ *   ]
+ * });
+ * // "(address,uint256)[]"
+ * ```
+ */
+export function formatCanonicalType(param) {
+	const type = param.type;
+
+	// Handle tuple types
+	if (type === "tuple" && param.components) {
+		const inner = param.components.map(formatCanonicalType).join(",");
+		return `(${inner})`;
+	}
+
+	// Handle tuple arrays (tuple[], tuple[3], etc.)
+	if (type.startsWith("tuple") && param.components) {
+		const arraySuffix = type.slice(5); // Get "[]" or "[3]" etc.
+		const inner = param.components.map(formatCanonicalType).join(",");
+		return `(${inner})${arraySuffix}`;
+	}
+
+	// Non-tuple types are used as-is
+	return type;
+}

--- a/src/primitives/Abi/formatCanonicalType.test.ts
+++ b/src/primitives/Abi/formatCanonicalType.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for formatCanonicalType function
+ */
+
+import { describe, expect, it } from "vitest";
+import { formatCanonicalType } from "./formatCanonicalType.js";
+
+describe("formatCanonicalType", () => {
+	describe("non-tuple types", () => {
+		it("returns simple types as-is", () => {
+			expect(formatCanonicalType({ type: "address", name: "to" })).toBe(
+				"address",
+			);
+			expect(formatCanonicalType({ type: "uint256", name: "amount" })).toBe(
+				"uint256",
+			);
+			expect(formatCanonicalType({ type: "bool", name: "flag" })).toBe("bool");
+			expect(formatCanonicalType({ type: "bytes32", name: "hash" })).toBe(
+				"bytes32",
+			);
+			expect(formatCanonicalType({ type: "string", name: "text" })).toBe(
+				"string",
+			);
+			expect(formatCanonicalType({ type: "bytes", name: "data" })).toBe("bytes");
+		});
+
+		it("returns array types as-is", () => {
+			expect(formatCanonicalType({ type: "uint256[]", name: "values" })).toBe(
+				"uint256[]",
+			);
+			expect(formatCanonicalType({ type: "address[]", name: "addrs" })).toBe(
+				"address[]",
+			);
+			expect(formatCanonicalType({ type: "uint256[3]", name: "fixed" })).toBe(
+				"uint256[3]",
+			);
+		});
+	});
+
+	describe("tuple types", () => {
+		it("expands simple tuple", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "data",
+				components: [
+					{ type: "address", name: "addr" },
+					{ type: "uint256", name: "value" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,uint256)");
+		});
+
+		it("expands tuple with single component", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "data",
+				components: [{ type: "uint256", name: "value" }],
+			};
+			expect(formatCanonicalType(param)).toBe("(uint256)");
+		});
+
+		it("expands tuple with many components", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "data",
+				components: [
+					{ type: "address", name: "a" },
+					{ type: "uint256", name: "b" },
+					{ type: "bool", name: "c" },
+					{ type: "bytes32", name: "d" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,uint256,bool,bytes32)");
+		});
+	});
+
+	describe("tuple array types", () => {
+		it("expands tuple[]", () => {
+			const param = {
+				type: "tuple[]" as const,
+				name: "items",
+				components: [
+					{ type: "address", name: "addr" },
+					{ type: "uint256", name: "value" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,uint256)[]");
+		});
+
+		it("expands fixed-size tuple array", () => {
+			const param = {
+				type: "tuple[3]" as const,
+				name: "items",
+				components: [
+					{ type: "address", name: "addr" },
+					{ type: "uint256", name: "value" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,uint256)[3]");
+		});
+
+		it("expands nested tuple arrays", () => {
+			const param = {
+				type: "tuple[][]" as const,
+				name: "matrix",
+				components: [
+					{ type: "uint256", name: "x" },
+					{ type: "uint256", name: "y" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(uint256,uint256)[][]");
+		});
+	});
+
+	describe("nested tuples", () => {
+		it("expands nested tuple", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "outer",
+				components: [
+					{
+						type: "tuple" as const,
+						name: "inner",
+						components: [{ type: "uint256", name: "value" }],
+					},
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("((uint256))");
+		});
+
+		it("expands deeply nested tuple", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "outer",
+				components: [
+					{ type: "address", name: "user" },
+					{
+						type: "tuple" as const,
+						name: "inner",
+						components: [
+							{ type: "uint256", name: "x" },
+							{ type: "uint256", name: "y" },
+						],
+					},
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,(uint256,uint256))");
+		});
+
+		it("expands tuple with nested tuple array", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "data",
+				components: [
+					{ type: "address", name: "owner" },
+					{
+						type: "tuple[]" as const,
+						name: "items",
+						components: [
+							{ type: "uint256", name: "id" },
+							{ type: "uint256", name: "amount" },
+						],
+					},
+				],
+			};
+			expect(formatCanonicalType(param)).toBe("(address,(uint256,uint256)[])");
+		});
+	});
+
+	describe("real-world examples", () => {
+		it("handles Uniswap V3 ExactInputSingleParams", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "params",
+				components: [
+					{ type: "address", name: "tokenIn" },
+					{ type: "address", name: "tokenOut" },
+					{ type: "uint24", name: "fee" },
+					{ type: "address", name: "recipient" },
+					{ type: "uint256", name: "deadline" },
+					{ type: "uint256", name: "amountIn" },
+					{ type: "uint256", name: "amountOutMinimum" },
+					{ type: "uint160", name: "sqrtPriceLimitX96" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe(
+				"(address,address,uint24,address,uint256,uint256,uint256,uint160)",
+			);
+		});
+
+		it("handles compound struct with nested arrays", () => {
+			const param = {
+				type: "tuple" as const,
+				name: "order",
+				components: [
+					{ type: "address", name: "maker" },
+					{ type: "address", name: "taker" },
+					{
+						type: "tuple[]" as const,
+						name: "items",
+						components: [
+							{ type: "address", name: "token" },
+							{ type: "uint256", name: "amount" },
+						],
+					},
+					{ type: "bytes32", name: "nonce" },
+				],
+			};
+			expect(formatCanonicalType(param)).toBe(
+				"(address,address,(address,uint256)[],bytes32)",
+			);
+		});
+	});
+});

--- a/src/primitives/Abi/function.test.ts
+++ b/src/primitives/Abi/function.test.ts
@@ -80,7 +80,7 @@ describe("Abi.Function.getSignature", () => {
 			],
 			outputs: [],
 		};
-		expect(Abi.Function.getSignature(func)).toBe("swap(tuple)");
+		expect(Abi.Function.getSignature(func)).toBe("swap((address,uint256))");
 	});
 
 	it("generates signature with arrays", () => {

--- a/src/primitives/Abi/function/getSignature.js
+++ b/src/primitives/Abi/function/getSignature.js
@@ -1,3 +1,5 @@
+import { formatCanonicalType } from "../formatCanonicalType.js";
+
 /**
  * Get function signature string (name(type1,type2,...))
  *
@@ -25,6 +27,6 @@
  * ```
  */
 export function getSignature(fn) {
-	const inputs = fn.inputs.map((p) => p.type).join(",");
+	const inputs = fn.inputs.map((p) => formatCanonicalType(p)).join(",");
 	return `${fn.name}(${inputs})`;
 }

--- a/src/primitives/Abi/function/getSignature.test.ts
+++ b/src/primitives/Abi/function/getSignature.test.ts
@@ -104,7 +104,7 @@ describe("getSignature", () => {
 				outputs: [],
 			} as const;
 
-			expect(getSignature(func)).toBe("processData(tuple)");
+			expect(getSignature(func)).toBe("processData((address,uint256))");
 		});
 
 		it("handles tuple array", () => {
@@ -125,7 +125,7 @@ describe("getSignature", () => {
 				outputs: [],
 			} as const;
 
-			expect(getSignature(func)).toBe("processTuples(tuple[])");
+			expect(getSignature(func)).toBe("processTuples((address,uint256)[])");
 		});
 
 		it("handles nested tuples", () => {
@@ -149,7 +149,7 @@ describe("getSignature", () => {
 				outputs: [],
 			} as const;
 
-			expect(getSignature(func)).toBe("processNested(tuple)");
+			expect(getSignature(func)).toBe("processNested(((uint256)))");
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Fixes #59
- ABI.getSignature() now expands tuple parameters to canonical form
- `foo(tuple)` becomes `foo((uint256,address))`
- Added formatCanonicalType helper for recursive tuple expansion
- Updated function, error, and event getSignature implementations

## Test plan
- [x] Added formatCanonicalType tests (13 tests covering simple, nested, array tuples)
- [x] Updated getSignature tests for function/error/event
- [x] Ran full Abi test suite (22118 tests pass)

🤖 Generated with [Claude Code](https://claude.ai/code)