### PR TITLE
fix: Export Hex.concat and other manipulation functions

### DIFF
--- a/src/primitives/Hex/index.ts
+++ b/src/primitives/Hex/index.ts
@@ -4,3 +4,32 @@ export * from "./Hex.js";
 export { default, Hex } from "./Hex.js";
 // Export type definitions (Hex type conflicts with Hex function, rename to HexType)
 export type { Bytes, Hex as HexBrand, HexType, Sized } from "./HexType.js";
+
+// Export manipulation functions for namespace import pattern: import * as Hex from '@tevm/voltaire/Hex'
+export {
+	concat,
+	slice,
+	pad,
+	padRight,
+	trim,
+	xor,
+	clone,
+	equals,
+	size,
+	isSized,
+	assertSize,
+	random,
+	zero,
+	validate,
+	isHex,
+	from,
+	fromBigInt,
+	fromBoolean,
+	fromNumber,
+	fromString,
+	toBigInt,
+	toBoolean,
+	toNumber,
+	// biome-ignore lint/suspicious/noShadowRestrictedNames: toString is intentional API name
+	toString,
+} from "./internal-index.js";


### PR DESCRIPTION
## Summary
- Fixes #154
- Exports all documented Hex manipulation functions for namespace import pattern
- Functions now available: `concat`, `slice`, `pad`, `padRight`, `trim`, `xor`, `clone`, `equals`, `size`, `isSized`, `assertSize`, `random`, `zero`, `validate`, `isHex`, `from`, `fromBigInt`, `fromBoolean`, `fromNumber`, `fromString`, `toBigInt`, `toBoolean`, `toNumber`, `toString`

## Test plan
- [x] All 489 Hex tests pass
- [x] Verified namespace import works: `import * as Hex from '@tevm/voltaire/Hex'`
- [x] Verified `Hex.concat('0x1234', '0x5678')` returns `'0x12345678'`

🤖 Generated with [Claude Code](https://claude.ai/code)