### PR TITLE
feat: Add Rlp.decodeValue() for simpler decoding

### DIFF
--- a/src/primitives/Rlp/decodeValue.js
+++ b/src/primitives/Rlp/decodeValue.js
@@ -1,0 +1,54 @@
+import { decode } from "./decode.js";
+
+/**
+ * @typedef {Uint8Array | RawRlpValue[]} RawRlpValue
+ */
+
+/**
+ * Converts BrandedRlp data structure to raw value
+ * @internal
+ * @param {import('./RlpType.js').BrandedRlp} data
+ * @returns {RawRlpValue}
+ */
+function toRawValue(data) {
+	if (data.type === "bytes") {
+		return data.value;
+	}
+	return data.value.map(toRawValue);
+}
+
+/**
+ * Decodes RLP-encoded bytes and returns just the decoded value
+ *
+ * This is a convenience wrapper around decode() that extracts the value directly,
+ * omitting the remainder and type metadata. Use this when you have complete RLP data
+ * and just want the decoded result.
+ *
+ * @see https://voltaire.tevm.sh/primitives/rlp for RLP documentation
+ * @since 0.1.42
+ * @param {Uint8Array} bytes - RLP-encoded data
+ * @returns {RawRlpValue} Decoded value (Uint8Array for bytes, array for list)
+ * @throws {import('./RlpError.js').RlpDecodingError} If input is too short, invalid, or has extra data
+ * @example
+ * ```javascript
+ * import * as Rlp from './primitives/Rlp/index.js';
+ *
+ * // Decode bytes - returns Uint8Array directly
+ * const bytes = new Uint8Array([0x83, 1, 2, 3]);
+ * const value = Rlp.decodeValue(bytes);
+ * // => Uint8Array([1, 2, 3])
+ *
+ * // Decode list - returns array directly
+ * const list = new Uint8Array([0xc3, 0x01, 0x02, 0x03]);
+ * const items = Rlp.decodeValue(list);
+ * // => [Uint8Array([1]), Uint8Array([2]), Uint8Array([3])]
+ *
+ * // Compare with decode() which returns full structure:
+ * // Rlp.decode(bytes) => { data: { type: 'bytes', value: Uint8Array([1,2,3]) }, remainder: Uint8Array([]) }
+ * // Rlp.decodeValue(bytes) => Uint8Array([1, 2, 3])
+ * ```
+ */
+export function decodeValue(bytes) {
+	const { data } = decode(bytes, false);
+	return toRawValue(data);
+}

--- a/src/primitives/Rlp/decodeValue.test.ts
+++ b/src/primitives/Rlp/decodeValue.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { decodeValue, encode, from, decode } from "./internal-index.js";
+import { RlpDecodingError } from "./RlpError.js";
+
+describe("decodeValue", () => {
+	describe("bytes decoding", () => {
+		it("decodes single byte (0x00-0x7f)", () => {
+			const encoded = encode(from(new Uint8Array([0x42])));
+			const value = decodeValue(encoded);
+			expect(value).toBeInstanceOf(Uint8Array);
+			expect(value).toEqual(new Uint8Array([0x42]));
+		});
+
+		it("decodes short bytes (1-55 bytes)", () => {
+			const input = new Uint8Array([1, 2, 3]);
+			const encoded = encode(from(input));
+			const value = decodeValue(encoded);
+			expect(value).toEqual(input);
+		});
+
+		it("decodes long bytes (>55 bytes)", () => {
+			const input = new Uint8Array(100).fill(0xaa);
+			const encoded = encode(from(input));
+			const value = decodeValue(encoded);
+			expect(value).toEqual(input);
+		});
+
+		it("decodes empty bytes", () => {
+			const encoded = new Uint8Array([0x80]);
+			const value = decodeValue(encoded);
+			expect(value).toEqual(new Uint8Array([]));
+		});
+	});
+
+	describe("list decoding", () => {
+		it("decodes simple list", () => {
+			const encoded = new Uint8Array([0xc3, 0x01, 0x02, 0x03]);
+			const value = decodeValue(encoded);
+			expect(Array.isArray(value)).toBe(true);
+			expect(value).toHaveLength(3);
+			expect(value[0]).toEqual(new Uint8Array([0x01]));
+			expect(value[1]).toEqual(new Uint8Array([0x02]));
+			expect(value[2]).toEqual(new Uint8Array([0x03]));
+		});
+
+		it("decodes empty list", () => {
+			const encoded = new Uint8Array([0xc0]);
+			const value = decodeValue(encoded);
+			expect(Array.isArray(value)).toBe(true);
+			expect(value).toHaveLength(0);
+		});
+
+		it("decodes nested list", () => {
+			// [[1, 2], [3]]
+			const inner1 = from([from(new Uint8Array([1])), from(new Uint8Array([2]))]);
+			const inner2 = from([from(new Uint8Array([3]))]);
+			const outer = from([inner1, inner2]);
+			const encoded = encode(outer);
+			const value = decodeValue(encoded);
+
+			expect(Array.isArray(value)).toBe(true);
+			expect(value).toHaveLength(2);
+			expect(Array.isArray(value[0])).toBe(true);
+			expect(Array.isArray(value[1])).toBe(true);
+			expect(value[0]).toHaveLength(2);
+			expect(value[1]).toHaveLength(1);
+		});
+	});
+
+	describe("comparison with decode()", () => {
+		it("returns value directly instead of wrapped object", () => {
+			const input = new Uint8Array([1, 2, 3]);
+			const encoded = encode(from(input));
+
+			// decode() returns { data: { type, value }, remainder }
+			const fullResult = decode(encoded);
+			expect(fullResult).toHaveProperty("data");
+			expect(fullResult).toHaveProperty("remainder");
+			expect(fullResult.data).toHaveProperty("type", "bytes");
+			expect(fullResult.data).toHaveProperty("value");
+
+			// decodeValue() returns value directly
+			const value = decodeValue(encoded);
+			expect(value).toEqual(input);
+			expect(value).not.toHaveProperty("data");
+			expect(value).not.toHaveProperty("remainder");
+		});
+	});
+
+	describe("error handling", () => {
+		it("throws on empty input", () => {
+			expect(() => decodeValue(new Uint8Array([]))).toThrow(RlpDecodingError);
+		});
+
+		it("throws on extra data after value", () => {
+			// Valid RLP byte followed by extra data
+			const withExtra = new Uint8Array([0x01, 0x02]);
+			expect(() => decodeValue(withExtra)).toThrow(RlpDecodingError);
+		});
+
+		it("throws on truncated data", () => {
+			// Says 3 bytes but only has 2
+			const truncated = new Uint8Array([0x83, 0x01, 0x02]);
+			expect(() => decodeValue(truncated)).toThrow(RlpDecodingError);
+		});
+	});
+});

--- a/src/primitives/Rlp/index.ts
+++ b/src/primitives/Rlp/index.ts
@@ -40,6 +40,7 @@ Rlp.encodeVariadic = BrandedRlpNs.encodeVariadic;
 Rlp.decode = BrandedRlpNs.decode;
 Rlp.decodeArray = BrandedRlpNs.decodeArray;
 Rlp.decodeObject = BrandedRlpNs.decodeObject;
+Rlp.decodeValue = BrandedRlpNs.decodeValue;
 Rlp.getEncodedLength = BrandedRlpNs.getEncodedLength;
 Rlp.flatten = BrandedRlpNs.flatten;
 Rlp.equals = BrandedRlpNs.equals;

--- a/src/primitives/Rlp/internal-index.ts
+++ b/src/primitives/Rlp/internal-index.ts
@@ -7,6 +7,7 @@ export * from "./RlpType.js";
 import { decode } from "./decode.js";
 import { decodeArray } from "./decodeArray.js";
 import { decodeBatch } from "./decodeBatch.js";
+import { decodeValue } from "./decodeValue.js";
 import { decodeObject } from "./decodeObject.js";
 import { encode } from "./encode.js";
 import { encodeArray } from "./encodeArray.js";
@@ -46,6 +47,7 @@ export {
 	decode,
 	decodeArray,
 	decodeObject,
+	decodeValue,
 	getEncodedLength,
 	flatten,
 	equals,
@@ -76,6 +78,7 @@ export const BrandedRlp = {
 	decode,
 	decodeArray,
 	decodeObject,
+	decodeValue,
 	getEncodedLength,
 	flatten,
 	equals,


### PR DESCRIPTION
## Summary
- Fixes #152
- Adds `Rlp.decodeValue()` that returns decoded value directly (Uint8Array for bytes, array for lists)
- Keeps `decode()` for streaming/partial decoding use cases that need the remainder

## Test plan
- [x] Added 11 tests for decodeValue covering bytes, lists, nested structures, and error cases
- [x] Ran Rlp tests

🤖 Generated with [Claude Code](https://claude.ai/code)