### PR TITLE
fix: Prevent blob gas price underflow (EIP-4844)

### DIFF
--- a/src/primitives/FeeMarket/FeeMarket.test.ts
+++ b/src/primitives/FeeMarket/FeeMarket.test.ts
@@ -146,6 +146,12 @@ describe("FeeMarket.BaseFee", () => {
 // ============================================================================
 
 describe("FeeMarket.fakeExponential", () => {
+	it("returns minimum 1 when result would be zero", () => {
+		// Edge case: factor=0 would result in 0, but we enforce minimum of 1
+		const result = fakeExponential(0n, 0n, 1_000_000n);
+		expect(result).toBe(1n);
+	});
+
 	it("returns factor when numerator is zero", () => {
 		const result = fakeExponential(1_000_000n, 0n, 1_000_000n);
 		expect(result).toBe(1_000_000n); // e^0 = 1
@@ -216,6 +222,12 @@ describe("FeeMarket.fakeExponential", () => {
 });
 
 describe("FeeMarket.BlobBaseFee", () => {
+	it("never returns zero (minimum is 1)", () => {
+		// Edge case: even with 0 excess, minimum is 1
+		const fee = FeeMarket.BlobBaseFee(0n);
+		expect(fee).toBeGreaterThanOrEqual(1n);
+	});
+
 	it("returns minimum fee with no excess", () => {
 		const fee = FeeMarket.BlobBaseFee(0n);
 		expect(fee).toBe(FeeMarket.Eip4844.MIN_BLOB_BASE_FEE);

--- a/src/primitives/FeeMarket/fakeExponential.js
+++ b/src/primitives/FeeMarket/fakeExponential.js
@@ -33,5 +33,9 @@ export function fakeExponential(factor, numerator, denominator) {
 		i += 1n;
 	}
 
-	return output / denominator;
+	const result = output / denominator;
+
+	// Per EIP-4844: minimum blob gas price is 1 (MIN_BLOB_BASE_FEE)
+	// Ensure we never return 0 to prevent underflow in callers
+	return result === 0n ? 1n : result;
 }


### PR DESCRIPTION
## Summary
- Fixes #138
- `fakeExponential` now enforces minimum return value of 1 (MIN_BLOB_BASE_FEE)
- Zig implementation uses u128 internally to prevent overflow during calculation
- TypeScript implementation ensures result is never 0n
- Added edge case tests for zero factor scenarios

## Test plan
- [x] Added edge case tests for fakeExponential with zero factor
- [x] Added edge case tests for BlobBaseFee minimum enforcement
- [x] Zig tests pass (`zig build test`)
- [x] TypeScript tests pass (`pnpm test:run -- FeeMarket`)

🤖 Generated with [Claude Code](https://claude.ai/code)