### PR TITLE
fix: Validate Scrypt N is power of 2

### DIFF
--- a/src/crypto/Keystore/decrypt.js
+++ b/src/crypto/Keystore/decrypt.js
@@ -4,6 +4,7 @@ import { decryptAesCtr } from "./aesCtr.js";
 import {
 	DecryptionError,
 	InvalidMacError,
+	InvalidScryptNError,
 	UnsupportedKdfError,
 	UnsupportedVersionError,
 } from "./errors.js";
@@ -83,7 +84,8 @@ export function decrypt(keystore, password) {
 		if (
 			error instanceof UnsupportedVersionError ||
 			error instanceof UnsupportedKdfError ||
-			error instanceof InvalidMacError
+			error instanceof InvalidMacError ||
+			error instanceof InvalidScryptNError
 		) {
 			throw error;
 		}

--- a/src/crypto/Keystore/encrypt.js
+++ b/src/crypto/Keystore/encrypt.js
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { keccak_256 } from "@noble/hashes/sha3.js";
 import { encryptAesCtr } from "./aesCtr.js";
-import { EncryptionError } from "./errors.js";
+import { EncryptionError, InvalidScryptNError } from "./errors.js";
 import { derivePbkdf2, deriveScrypt } from "./kdf.js";
 import { bytesToHex, concat, generateUuid } from "./utils.js";
 
@@ -96,6 +96,9 @@ export async function encrypt(privateKey, password, options = {}) {
 
 		return keystore;
 	} catch (error) {
+		if (error instanceof InvalidScryptNError) {
+			throw error;
+		}
 		throw new EncryptionError(`Encryption failed: ${error.message}`);
 	}
 }

--- a/src/crypto/Keystore/errors.js
+++ b/src/crypto/Keystore/errors.js
@@ -189,3 +189,38 @@ export class EncryptionError extends KeystoreError {
 		this.name = "EncryptionError";
 	}
 }
+
+/**
+ * Error thrown when scrypt N parameter is not a power of 2
+ *
+ * Scrypt requires N to be a power of 2 for correct operation.
+ *
+ * @see https://voltaire.tevm.sh/crypto/keystore
+ * @since 0.1.42
+ */
+export class InvalidScryptNError extends KeystoreError {
+	/** @type {number} */
+	n;
+
+	/**
+	 * @param {number} n
+	 * @param {object} [options]
+	 * @param {string} [options.code]
+	 * @param {Record<string, unknown>} [options.context]
+	 * @param {string} [options.docsPath]
+	 * @param {Error} [options.cause]
+	 */
+	constructor(n, options) {
+		super(
+			`Invalid scrypt N parameter: ${n}. N must be a power of 2 (e.g., 1024, 2048, 4096, 16384, 262144).`,
+			{
+				code: options?.code || "INVALID_SCRYPT_N",
+				context: { n, ...options?.context },
+				docsPath: options?.docsPath || "/crypto/keystore#error-handling",
+				cause: options?.cause,
+			},
+		);
+		this.name = "InvalidScryptNError";
+		this.n = n;
+	}
+}

--- a/src/crypto/Keystore/kdf.js
+++ b/src/crypto/Keystore/kdf.js
@@ -2,17 +2,29 @@
 import { pbkdf2 } from "@noble/hashes/pbkdf2.js";
 import { scrypt } from "@noble/hashes/scrypt.js";
 import { sha256 } from "@noble/hashes/sha2.js";
+import { InvalidScryptNError } from "./errors.js";
+
+/**
+ * Check if a number is a power of 2
+ *
+ * @param {number} n - Number to check
+ * @returns {boolean} True if n is a power of 2
+ */
+export function isPowerOfTwo(n) {
+	return Number.isInteger(n) && n > 0 && (n & (n - 1)) === 0;
+}
 
 /**
  * Derive key using scrypt KDF
  *
  * @param {string | Uint8Array} password - Password
  * @param {Uint8Array} salt - Salt (32 bytes recommended)
- * @param {number} n - CPU/memory cost parameter (default: 262144)
+ * @param {number} n - CPU/memory cost parameter (default: 262144). Must be a power of 2.
  * @param {number} r - Block size parameter (default: 8)
  * @param {number} p - Parallelization parameter (default: 1)
  * @param {number} dklen - Derived key length (default: 32)
  * @returns {Uint8Array} Derived key
+ * @throws {InvalidScryptNError} If n is not a power of 2
  */
 export function deriveScrypt(
 	password,
@@ -22,6 +34,10 @@ export function deriveScrypt(
 	p = 1,
 	dklen = 32,
 ) {
+	if (!isPowerOfTwo(n)) {
+		throw new InvalidScryptNError(n);
+	}
+
 	const passwordBytes =
 		typeof password === "string"
 			? new TextEncoder().encode(password)


### PR DESCRIPTION
## Summary
- Fixes #126
- Scrypt N parameter validated as power of 2 before calling scrypt
- Added `InvalidScryptNError` error class for invalid cost factors
- Validation applies to both encrypt and decrypt operations

## Test plan
- [x] Added tests for invalid N values (0, -1, 3, 1000)
- [x] Added tests for valid power of 2 N values (2, 4, 8, ... 2048)
- [x] Added test for invalid N during decrypt
- [x] Ran Keystore tests - all passing

🤖 Generated with [Claude Code](https://claude.ai/code)