### PR TITLE
fix: Handle all field types in Block.fromRPC()

### DIFF
--- a/src/primitives/Block/Block.test.ts
+++ b/src/primitives/Block/Block.test.ts
@@ -22,6 +22,45 @@ describe("Block", () => {
 		nonce: new Uint8Array(8),
 	};
 
+	// Real-world RPC response example (Cancun block)
+	const rpcBlockResponse = {
+		hash: "0xe27a3e81bd7cfe2aec2cc9e832c73a17c93e7efcf659cf4b39883b96c48708c2",
+		parentHash:
+			"0x4b9d85c6787612e87e0659e11a347d415040465e492358f79cc7e2e293f38aa7",
+		sha3Uncles:
+			"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		miner: "0x0000000000000000000000000000000000000000",
+		stateRoot:
+			"0xf61892bbb9a9df427d1f941dc8c536d72c41efed598244726ea21a0f183ff232",
+		transactionsRoot:
+			"0xc541c333ff4a96a17d3601f7d628ea27ecf4597a11077e5d9d1c4dbed6c7f401",
+		receiptsRoot:
+			"0x2c86b2791cdd088d3c3e9d6225f71724d3e8c67bdd13cd6208831058cee1043f",
+		logsBloom:
+			"0x00000000008000000000000000000040000000000000000000000000800000000000000008000000000000000000000000000000000000000000000000000000000000000000000000004000000000020200000000000000000000000000002000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000009000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		difficulty: "0x0",
+		number: "0x2d",
+		gasLimit: "0x47e7c40",
+		gasUsed: "0x54a92",
+		timestamp: "0x1c2",
+		extraData: "0x",
+		mixHash:
+			"0x0000000000000000000000000000000000000000000000000000000000000000",
+		nonce: "0x0000000000000000",
+		baseFeePerGas: "0x5763d64",
+		size: "0x633",
+		totalDifficulty: "0x0",
+		blobGasUsed: "0x0",
+		excessBlobGas: "0x0",
+		parentBeaconBlockRoot:
+			"0x4b118bd31ed2c4eeb81dc9e3919e9989994333fe36f147c2930f12c53f0d3c78",
+		withdrawalsRoot:
+			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		transactions: [],
+		uncles: [],
+		withdrawals: [],
+	};
+
 	const validBody = {
 		transactions: [],
 		ommers: [],
@@ -107,6 +146,217 @@ describe("Block", () => {
 
 			expect(block.header.difficulty).toBe(0n);
 			expect(block.totalDifficulty).toBeUndefined();
+		});
+	});
+
+	describe("fromRpc", () => {
+		it("parses block from RPC response", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.hash).toHaveLength(32);
+			expect(block.header.number).toBe(0x2dn);
+			expect(block.header.gasLimit).toBe(0x47e7c40n);
+			expect(block.header.gasUsed).toBe(0x54a92n);
+			expect(block.header.timestamp).toBe(0x1c2n);
+			expect(block.header.difficulty).toBe(0n);
+			expect(block.size).toBe(0x633n);
+			expect(block.totalDifficulty).toBe(0n);
+			expect(block.body.transactions).toHaveLength(0);
+			expect(block.body.ommers).toHaveLength(0);
+		});
+
+		it("parses EIP-1559 fields", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.header.baseFeePerGas).toBe(0x5763d64n);
+		});
+
+		it("parses EIP-4844 fields", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.header.blobGasUsed).toBe(0n);
+			expect(block.header.excessBlobGas).toBe(0n);
+			expect(block.header.parentBeaconBlockRoot).toHaveLength(32);
+		});
+
+		it("parses withdrawals root", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.header.withdrawalsRoot).toHaveLength(32);
+		});
+
+		it("handles null optional fields", () => {
+			const rpcWithNulls = {
+				...rpcBlockResponse,
+				baseFeePerGas: null,
+				withdrawalsRoot: null,
+				blobGasUsed: null,
+				excessBlobGas: null,
+				parentBeaconBlockRoot: null,
+				totalDifficulty: null,
+			};
+
+			const block = Block.fromRpc(rpcWithNulls);
+
+			expect(block.header.baseFeePerGas).toBeUndefined();
+			expect(block.header.withdrawalsRoot).toBeUndefined();
+			expect(block.header.blobGasUsed).toBeUndefined();
+			expect(block.header.excessBlobGas).toBeUndefined();
+			expect(block.header.parentBeaconBlockRoot).toBeUndefined();
+			expect(block.totalDifficulty).toBeUndefined();
+		});
+
+		it("handles pre-London block (no baseFeePerGas)", () => {
+			const preLondonRpc = {
+				hash: "0xe27a3e81bd7cfe2aec2cc9e832c73a17c93e7efcf659cf4b39883b96c48708c2",
+				parentHash:
+					"0x4b9d85c6787612e87e0659e11a347d415040465e492358f79cc7e2e293f38aa7",
+				sha3Uncles:
+					"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+				miner: "0x0000000000000000000000000000000000000000",
+				stateRoot:
+					"0xf61892bbb9a9df427d1f941dc8c536d72c41efed598244726ea21a0f183ff232",
+				transactionsRoot:
+					"0xc541c333ff4a96a17d3601f7d628ea27ecf4597a11077e5d9d1c4dbed6c7f401",
+				receiptsRoot:
+					"0x2c86b2791cdd088d3c3e9d6225f71724d3e8c67bdd13cd6208831058cee1043f",
+				logsBloom:
+					"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+				difficulty: "0x1234567890",
+				number: "0x2d",
+				gasLimit: "0x47e7c40",
+				gasUsed: "0x54a92",
+				timestamp: "0x1c2",
+				extraData: "0x",
+				mixHash:
+					"0x0000000000000000000000000000000000000000000000000000000000000000",
+				nonce: "0x0000000000000000",
+				size: "0x633",
+				totalDifficulty: "0x9876543210",
+			};
+
+			const block = Block.fromRpc(preLondonRpc);
+
+			expect(block.header.difficulty).toBe(0x1234567890n);
+			expect(block.totalDifficulty).toBe(0x9876543210n);
+			expect(block.header.baseFeePerGas).toBeUndefined();
+		});
+
+		it("parses block with withdrawals", () => {
+			const rpcWithWithdrawals = {
+				...rpcBlockResponse,
+				withdrawals: [
+					{
+						index: "0x1",
+						validatorIndex: "0x2",
+						address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+						amount: "0x3b9aca00",
+					},
+					{
+						index: "0x2",
+						validatorIndex: "0x3",
+						address: "0x8626f6940E2eb28930eFb4CeF49B2d1F2C9C1199",
+						amount: "0x77359400",
+					},
+				],
+			};
+
+			const block = Block.fromRpc(rpcWithWithdrawals);
+
+			expect(block.body.withdrawals).toHaveLength(2);
+			// WithdrawalIndex is bigint, ValidatorIndex is number, amount is string (Gwei)
+			expect(block.body.withdrawals?.[0].index).toBe(1n);
+			expect(block.body.withdrawals?.[0].validatorIndex).toBe(2);
+			expect(block.body.withdrawals?.[0].amount).toBe("1000000000"); // 0x3b9aca00 = 1000000000
+			expect(block.body.withdrawals?.[1].index).toBe(2n);
+			expect(block.body.withdrawals?.[1].validatorIndex).toBe(3);
+			expect(block.body.withdrawals?.[1].amount).toBe("2000000000"); // 0x77359400 = 2000000000
+		});
+
+		it("parses block with transactions", () => {
+			const rpcWithTxs = {
+				...rpcBlockResponse,
+				transactions: [
+					{
+						blockHash:
+							"0xe27a3e81bd7cfe2aec2cc9e832c73a17c93e7efcf659cf4b39883b96c48708c2",
+						blockNumber: "0x2d",
+						from: "0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f",
+						gas: "0x11c32",
+						gasPrice: "0x5763d65",
+						hash: "0x2fbbd036996c7487316c92b9e5798edb98fd57f32a6c1075e904a734821e1cd2",
+						input: "0x",
+						nonce: "0x9a",
+						to: "0x0000000000000000000000000000000000000000",
+						transactionIndex: "0x0",
+						value: "0x0",
+						type: "0x0",
+						chainId: "0xc72dd9d5e883e",
+						v: "0x18e5bb3abd109f",
+						r: "0x551fe45ccebb0318196e31dbc60da87c43dc60b8fb01afb3286693fa09878730",
+						s: "0x40d33e9afecfe1516b045d61a3272bddbc83f482a7f2c749311248b50fe62e81",
+					},
+				],
+			};
+
+			const block = Block.fromRpc(rpcWithTxs);
+
+			expect(block.body.transactions).toHaveLength(1);
+			expect(block.body.transactions[0].nonce).toBe(0x9an);
+			expect(block.body.transactions[0].gasLimit).toBe(0x11c32n);
+		});
+
+		it("handles transaction hashes (includeTransactions=false)", () => {
+			const rpcWithTxHashes = {
+				...rpcBlockResponse,
+				transactions: [
+					"0x2fbbd036996c7487316c92b9e5798edb98fd57f32a6c1075e904a734821e1cd2",
+					"0x16f6724ad864e7664c367893cae3e176d362bea3a47495cec3b246555a7228da",
+				],
+			};
+
+			const block = Block.fromRpc(rpcWithTxHashes, {
+				includeTransactions: false,
+			});
+
+			// When transactions are hashes, we don't parse them
+			expect(block.body.transactions).toHaveLength(0);
+		});
+
+		it("parses logsBloom correctly", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.header.logsBloom).toBeInstanceOf(Uint8Array);
+			expect(block.header.logsBloom).toHaveLength(256);
+		});
+
+		it("parses nonce correctly", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			expect(block.header.nonce).toBeInstanceOf(Uint8Array);
+			expect(block.header.nonce).toHaveLength(8);
+		});
+
+		it("parses extraData correctly", () => {
+			const rpcWithExtraData = {
+				...rpcBlockResponse,
+				extraData:
+					"0x6265617665726275696c642e6f7267", // "beaverbuild.org" in hex
+			};
+
+			const block = Block.fromRpc(rpcWithExtraData);
+
+			expect(block.header.extraData).toBeInstanceOf(Uint8Array);
+			expect(block.header.extraData).toHaveLength(15);
+		});
+
+		it("maps RPC field names to internal names", () => {
+			const block = Block.fromRpc(rpcBlockResponse);
+
+			// sha3Uncles -> ommersHash
+			expect(block.header.ommersHash).toHaveLength(32);
+			// miner -> beneficiary
+			expect(block.header.beneficiary).toHaveLength(20);
 		});
 	});
 });

--- a/src/primitives/Block/fromRpc.js
+++ b/src/primitives/Block/fromRpc.js
@@ -1,0 +1,147 @@
+import { from as blockHashFrom } from "../BlockHash/index.js";
+import { fromRpc as blockHeaderFromRpc } from "../BlockHeader/fromRpc.js";
+import { fromRpc as transactionFromRpc } from "../Transaction/fromRpc.js";
+import { from as uint256From } from "../Uint/index.js";
+import { from as withdrawalFrom } from "../Withdrawal/index.js";
+
+/**
+ * Convert hex string to bigint, handling null/undefined
+ * @param {string | null | undefined} hex
+ * @returns {bigint}
+ */
+function hexToBigInt(hex) {
+	if (!hex) return 0n;
+	return BigInt(hex);
+}
+
+/**
+ * @typedef {import('../BlockHeader/fromRpc.js').RpcBlockHeader} RpcBlockHeader
+ */
+
+/**
+ * @typedef {Object} RpcWithdrawal
+ * @property {string} index - Withdrawal index
+ * @property {string} validatorIndex - Validator index
+ * @property {string} address - Withdrawal recipient address
+ * @property {string} amount - Amount in Gwei
+ */
+
+/**
+ * @typedef {Object} RpcBlock
+ * @property {string} hash - Block hash
+ * @property {string} size - Block size in bytes
+ * @property {string | null} [totalDifficulty] - Total difficulty (pre-merge)
+ * @property {Array<import('../Transaction/fromRpc.js').RpcTransaction | string>} [transactions] - Transactions (full objects or hashes)
+ * @property {string[]} [uncles] - Uncle block hashes
+ * @property {RpcWithdrawal[]} [withdrawals] - Withdrawals (post-Shanghai)
+ */
+
+/**
+ * @typedef {RpcBlock & RpcBlockHeader} RpcBlockResponse
+ */
+
+/**
+ * Create Block from JSON-RPC response
+ *
+ * Converts hex-encoded RPC fields to appropriate internal types:
+ * - Hex strings (0x...) to bigint for numeric fields
+ * - Hex strings to Uint8Array for byte fields
+ * - Parses transactions if full objects are included
+ * - Maps RPC field names to internal names
+ *
+ * @see https://voltaire.tevm.sh/primitives/block for Block documentation
+ * @since 0.1.42
+ * @param {RpcBlockResponse} rpc - JSON-RPC eth_getBlockByNumber/eth_getBlockByHash response
+ * @param {object} [options] - Options
+ * @param {boolean} [options.includeTransactions=true] - Whether to parse transaction objects (false if response has tx hashes only)
+ * @returns {import('./BlockType.js').BlockType} Block
+ *
+ * @example
+ * ```javascript
+ * import * as Block from './primitives/Block/index.js';
+ *
+ * // From eth_getBlockByNumber with full transactions
+ * const block = Block.fromRpc({
+ *   hash: "0x1a2b3c...",
+ *   parentHash: "0xf1e2d3...",
+ *   sha3Uncles: "0x1dcc4de8...",
+ *   miner: "0x1f9090aa...",
+ *   stateRoot: "0xa1b2c3...",
+ *   transactionsRoot: "0xb2c3d4...",
+ *   receiptsRoot: "0xc3d4e5...",
+ *   logsBloom: "0x00000...",
+ *   difficulty: "0x0",
+ *   number: "0x12a7f27",
+ *   gasLimit: "0x1c9c380",
+ *   gasUsed: "0xd1a2b3",
+ *   timestamp: "0x65e8c8b7",
+ *   extraData: "0x",
+ *   mixHash: "0x0000...",
+ *   nonce: "0x0000000000000000",
+ *   baseFeePerGas: "0x7a1225a00",
+ *   size: "0xb1e2",
+ *   totalDifficulty: "0xc70d815d562d3cfa955",
+ *   transactions: [...],
+ *   uncles: [],
+ *   withdrawals: [...]
+ * });
+ * ```
+ */
+export function fromRpc(rpc, options = {}) {
+	const { includeTransactions = true } = options;
+
+	// Parse header fields
+	const header = blockHeaderFromRpc(rpc);
+
+	// Parse transactions
+	/** @type {import('../Transaction/types.js').Any[]} */
+	let transactions = [];
+	if (rpc.transactions && rpc.transactions.length > 0) {
+		if (includeTransactions && typeof rpc.transactions[0] === "object") {
+			transactions = rpc.transactions.map((tx) =>
+				transactionFromRpc(
+					/** @type {import('../Transaction/fromRpc.js').RpcTransaction} */ (tx),
+				),
+			);
+		}
+		// If transactions are hashes (strings), we leave the array empty
+		// as BlockBody.transactions expects Transaction objects, not hashes
+	}
+
+	// Parse withdrawals
+	/** @type {import('../Withdrawal/WithdrawalType.js').WithdrawalType[] | undefined} */
+	let withdrawals;
+	if (rpc.withdrawals) {
+		withdrawals = rpc.withdrawals.map((w) =>
+			withdrawalFrom({
+				index: hexToBigInt(w.index),
+				validatorIndex: hexToBigInt(w.validatorIndex),
+				address: w.address,
+				amount: hexToBigInt(w.amount),
+			}),
+		);
+	}
+
+	// Build body
+	/** @type {import('../BlockBody/BlockBodyType.js').BlockBodyType} */
+	const body = {
+		transactions,
+		ommers: [], // RPC doesn't include full uncle blocks, only hashes
+		...(withdrawals !== undefined && { withdrawals }),
+	};
+
+	// Build block
+	/** @type {import('./BlockType.js').BlockType} */
+	const block = {
+		header,
+		body,
+		hash: blockHashFrom(rpc.hash),
+		size: uint256From(hexToBigInt(rpc.size)),
+		...(rpc.totalDifficulty !== undefined &&
+			rpc.totalDifficulty !== null && {
+				totalDifficulty: uint256From(hexToBigInt(rpc.totalDifficulty)),
+			}),
+	};
+
+	return block;
+}

--- a/src/primitives/Block/index.ts
+++ b/src/primitives/Block/index.ts
@@ -3,9 +3,11 @@ export type { BlockType } from "./BlockType.js";
 
 // Import internal functions
 import { from as _from } from "./from.js";
+import { fromRpc as _fromRpc } from "./fromRpc.js";
 
 // Export internal functions (tree-shakeable)
 export { _from };
+export { _fromRpc };
 
 // Export public functions
 export function from(params: {
@@ -18,7 +20,70 @@ export function from(params: {
 	return _from(params);
 }
 
+/**
+ * RPC Withdrawal type
+ */
+export interface RpcWithdrawal {
+	index: string;
+	validatorIndex: string;
+	address: string;
+	amount: string;
+}
+
+/**
+ * RPC Block response (from eth_getBlockByNumber/Hash)
+ */
+export interface RpcBlock {
+	hash: string;
+	parentHash: string;
+	sha3Uncles: string;
+	miner: string;
+	stateRoot: string;
+	transactionsRoot: string;
+	receiptsRoot: string;
+	logsBloom: string;
+	difficulty: string;
+	number: string;
+	gasLimit: string;
+	gasUsed: string;
+	timestamp: string;
+	extraData: string;
+	mixHash: string;
+	nonce: string;
+	size: string;
+	totalDifficulty?: string | null;
+	baseFeePerGas?: string | null;
+	withdrawalsRoot?: string | null;
+	blobGasUsed?: string | null;
+	excessBlobGas?: string | null;
+	parentBeaconBlockRoot?: string | null;
+	transactions?: Array<
+		import("../Transaction/fromRpc.js").RpcTransaction | string
+	>;
+	uncles?: string[];
+	withdrawals?: RpcWithdrawal[];
+}
+
+/**
+ * Options for fromRpc
+ */
+export interface FromRpcOptions {
+	/** Whether to parse transaction objects (false if response has tx hashes only) */
+	includeTransactions?: boolean;
+}
+
+/**
+ * Create Block from JSON-RPC response
+ */
+export function fromRpc(
+	rpc: RpcBlock,
+	options?: FromRpcOptions,
+): import("./BlockType.js").BlockType {
+	return _fromRpc(rpc, options);
+}
+
 // Namespace export
 export const Block = {
 	from,
+	fromRpc,
 };

--- a/src/primitives/BlockHeader/fromRpc.js
+++ b/src/primitives/BlockHeader/fromRpc.js
@@ -1,0 +1,132 @@
+import { from as addressFrom } from "../Address/internal-index.js";
+import { from as blockHashFrom } from "../BlockHash/index.js";
+import { from as blockNumberFrom } from "../BlockNumber/index.js";
+import { from as hashFrom } from "../Hash/index.js";
+import { toBytes } from "../Hex/toBytes.js";
+import { from as uint256From } from "../Uint/index.js";
+
+/**
+ * Convert hex string to bigint, handling null/undefined
+ * @param {string | null | undefined} hex
+ * @returns {bigint}
+ */
+function hexToBigInt(hex) {
+	if (!hex) return 0n;
+	return BigInt(hex);
+}
+
+/**
+ * Convert hex string to Uint8Array, handling null/undefined
+ * @param {string | null | undefined} hex
+ * @returns {Uint8Array}
+ */
+function hexToBytes(hex) {
+	if (!hex || hex === "0x") return new Uint8Array(0);
+	return toBytes(hex);
+}
+
+/**
+ * @typedef {Object} RpcBlockHeader
+ * @property {string} parentHash - Parent block hash
+ * @property {string} sha3Uncles - Uncles/ommers hash
+ * @property {string} miner - Beneficiary address (also known as coinbase)
+ * @property {string} stateRoot - State trie root
+ * @property {string} transactionsRoot - Transactions trie root
+ * @property {string} receiptsRoot - Receipts trie root
+ * @property {string} logsBloom - Bloom filter for logs (512 hex chars)
+ * @property {string} difficulty - Block difficulty
+ * @property {string} number - Block number
+ * @property {string} gasLimit - Gas limit
+ * @property {string} gasUsed - Gas used
+ * @property {string} timestamp - Unix timestamp
+ * @property {string} extraData - Extra data
+ * @property {string} mixHash - Mix hash (PoW)
+ * @property {string} nonce - Nonce (PoW)
+ * @property {string | null} [baseFeePerGas] - Base fee per gas (EIP-1559)
+ * @property {string | null} [withdrawalsRoot] - Withdrawals root (post-Shanghai)
+ * @property {string | null} [blobGasUsed] - Blob gas used (EIP-4844)
+ * @property {string | null} [excessBlobGas] - Excess blob gas (EIP-4844)
+ * @property {string | null} [parentBeaconBlockRoot] - Parent beacon block root (EIP-4788)
+ */
+
+/**
+ * Create BlockHeader from JSON-RPC response
+ *
+ * Converts hex-encoded RPC fields to appropriate internal types:
+ * - Hex strings (0x...) to bigint for numeric fields
+ * - Hex strings to Uint8Array for byte fields
+ * - Maps RPC field names to internal names (sha3Uncles -> ommersHash, miner -> beneficiary)
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-header for BlockHeader documentation
+ * @since 0.1.42
+ * @param {RpcBlockHeader} rpc - JSON-RPC block header fields
+ * @returns {import('./BlockHeaderType.js').BlockHeaderType} BlockHeader
+ *
+ * @example
+ * ```javascript
+ * import * as BlockHeader from './primitives/BlockHeader/index.js';
+ *
+ * // From eth_getBlockByNumber response
+ * const header = BlockHeader.fromRpc({
+ *   parentHash: "0x1234...",
+ *   sha3Uncles: "0x5678...",
+ *   miner: "0xabcd...",
+ *   stateRoot: "0xef01...",
+ *   transactionsRoot: "0x2345...",
+ *   receiptsRoot: "0x6789...",
+ *   logsBloom: "0x00000...",
+ *   difficulty: "0x0",
+ *   number: "0x12345",
+ *   gasLimit: "0x1c9c380",
+ *   gasUsed: "0xd1a2b3",
+ *   timestamp: "0x65e8c8b7",
+ *   extraData: "0x",
+ *   mixHash: "0x0000...",
+ *   nonce: "0x0000000000000000",
+ *   baseFeePerGas: "0x7a1225a00",
+ *   withdrawalsRoot: "0xd4e5...",
+ *   blobGasUsed: "0x40000",
+ *   excessBlobGas: "0x20000",
+ *   parentBeaconBlockRoot: "0xe5f6..."
+ * });
+ * ```
+ */
+export function fromRpc(rpc) {
+	return /** @type {import('./BlockHeaderType.js').BlockHeaderType} */ ({
+		parentHash: blockHashFrom(rpc.parentHash),
+		ommersHash: hashFrom(rpc.sha3Uncles),
+		beneficiary: addressFrom(rpc.miner),
+		stateRoot: hashFrom(rpc.stateRoot),
+		transactionsRoot: hashFrom(rpc.transactionsRoot),
+		receiptsRoot: hashFrom(rpc.receiptsRoot),
+		logsBloom: hexToBytes(rpc.logsBloom),
+		difficulty: uint256From(hexToBigInt(rpc.difficulty)),
+		number: blockNumberFrom(hexToBigInt(rpc.number)),
+		gasLimit: uint256From(hexToBigInt(rpc.gasLimit)),
+		gasUsed: uint256From(hexToBigInt(rpc.gasUsed)),
+		timestamp: uint256From(hexToBigInt(rpc.timestamp)),
+		extraData: hexToBytes(rpc.extraData),
+		mixHash: hashFrom(rpc.mixHash),
+		nonce: hexToBytes(rpc.nonce),
+		...(rpc.baseFeePerGas !== undefined &&
+			rpc.baseFeePerGas !== null && {
+				baseFeePerGas: uint256From(hexToBigInt(rpc.baseFeePerGas)),
+			}),
+		...(rpc.withdrawalsRoot !== undefined &&
+			rpc.withdrawalsRoot !== null && {
+				withdrawalsRoot: hashFrom(rpc.withdrawalsRoot),
+			}),
+		...(rpc.blobGasUsed !== undefined &&
+			rpc.blobGasUsed !== null && {
+				blobGasUsed: uint256From(hexToBigInt(rpc.blobGasUsed)),
+			}),
+		...(rpc.excessBlobGas !== undefined &&
+			rpc.excessBlobGas !== null && {
+				excessBlobGas: uint256From(hexToBigInt(rpc.excessBlobGas)),
+			}),
+		...(rpc.parentBeaconBlockRoot !== undefined &&
+			rpc.parentBeaconBlockRoot !== null && {
+				parentBeaconBlockRoot: hashFrom(rpc.parentBeaconBlockRoot),
+			}),
+	});
+}

--- a/src/primitives/BlockHeader/index.ts
+++ b/src/primitives/BlockHeader/index.ts
@@ -3,9 +3,11 @@ export type { BlockHeaderType } from "./BlockHeaderType.js";
 
 // Import internal functions
 import { from as _from } from "./from.js";
+import { fromRpc as _fromRpc } from "./fromRpc.js";
 
 // Export internal functions (tree-shakeable)
 export { _from };
+export { _fromRpc };
 
 // Export public functions
 export function from(params: {
@@ -33,7 +35,43 @@ export function from(params: {
 	return _from(params as Parameters<typeof _from>[0]);
 }
 
+/**
+ * RPC Block Header fields (from eth_getBlockByNumber/Hash response)
+ */
+export interface RpcBlockHeader {
+	parentHash: string;
+	sha3Uncles: string;
+	miner: string;
+	stateRoot: string;
+	transactionsRoot: string;
+	receiptsRoot: string;
+	logsBloom: string;
+	difficulty: string;
+	number: string;
+	gasLimit: string;
+	gasUsed: string;
+	timestamp: string;
+	extraData: string;
+	mixHash: string;
+	nonce: string;
+	baseFeePerGas?: string | null;
+	withdrawalsRoot?: string | null;
+	blobGasUsed?: string | null;
+	excessBlobGas?: string | null;
+	parentBeaconBlockRoot?: string | null;
+}
+
+/**
+ * Create BlockHeader from JSON-RPC response
+ */
+export function fromRpc(
+	rpc: RpcBlockHeader,
+): import("./BlockHeaderType.js").BlockHeaderType {
+	return _fromRpc(rpc);
+}
+
 // Namespace export
 export const BlockHeader = {
 	from,
+	fromRpc,
 };


### PR DESCRIPTION
## Summary
- Fixes #145
- Adds `Block.fromRpc()` to convert JSON-RPC block responses to `BlockType`
- Adds `BlockHeader.fromRpc()` to convert header fields
- Correctly handles all field type conversions:
  - Hex strings (0x...) to bigint for numeric fields (gasLimit, gasUsed, timestamp, etc.)
  - Hex strings to Uint8Array for byte fields (logsBloom, nonce, extraData)
  - null → undefined for optional fields (baseFeePerGas, withdrawalsRoot, etc.)
  - Parses transaction arrays (full objects or skips if hashes)
  - Parses withdrawal arrays
- Maps RPC field names to internal names (sha3Uncles → ommersHash, miner → beneficiary)

## Test plan
- [x] Added 13 tests with real RPC response examples
- [x] Tests cover Cancun/Dencun blocks with EIP-4844 fields
- [x] Tests cover pre-London blocks without baseFeePerGas
- [x] Tests cover null optional fields
- [x] Tests cover blocks with withdrawals and transactions
- [x] All Block tests pass (`pnpm test:run -- src/primitives/Block/Block.test.ts`)

🤖 Generated with [Claude Code](https://claude.ai/code)