### PR TITLE
fix: Validate KZG proof is exactly 48 bytes

### DIFF
--- a/src/crypto/KZG/validation.test.ts
+++ b/src/crypto/KZG/validation.test.ts
@@ -423,6 +423,65 @@ describe.skipIf(!hasNativeKzg)("KZG Validation - Edge Cases", () => {
 				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
 			).toThrow(KzgInvalidBlobError);
 		});
+
+		it("should reject batch with invalid proof size (not 48 bytes)", () => {
+			const blobs = [KZG.generateRandomBlob(), KZG.generateRandomBlob()];
+			const commitments = blobs.map((b) => KZG.Commitment(b));
+			const proofs = [
+				new Uint8Array(BYTES_PER_PROOF),
+				new Uint8Array(32), // Wrong size - should be 48
+			];
+
+			expect(() =>
+				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
+			).toThrow(KzgError);
+		});
+
+		it("should reject batch with zero-length proof", () => {
+			const blobs = [KZG.generateRandomBlob()];
+			const commitments = blobs.map((b) => KZG.Commitment(b));
+			const proofs = [new Uint8Array(0)]; // Empty proof
+
+			expect(() =>
+				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
+			).toThrow(KzgError);
+		});
+
+		it("should reject batch with invalid commitment size (not 48 bytes)", () => {
+			const blobs = [KZG.generateRandomBlob(), KZG.generateRandomBlob()];
+			const commitments = [
+				new Uint8Array(BYTES_PER_COMMITMENT),
+				new Uint8Array(32), // Wrong size - should be 48
+			];
+			const proofs = [
+				new Uint8Array(BYTES_PER_PROOF),
+				new Uint8Array(BYTES_PER_PROOF),
+			];
+
+			expect(() =>
+				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
+			).toThrow(KzgError);
+		});
+
+		it("should reject batch with non-Uint8Array proof", () => {
+			const blobs = [KZG.generateRandomBlob()];
+			const commitments = blobs.map((b) => KZG.Commitment(b));
+			const proofs = ["not-a-uint8array" as unknown as Uint8Array];
+
+			expect(() =>
+				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
+			).toThrow(KzgError);
+		});
+
+		it("should reject batch with non-Uint8Array commitment", () => {
+			const blobs = [KZG.generateRandomBlob()];
+			const commitments = [null as unknown as Uint8Array];
+			const proofs = [new Uint8Array(BYTES_PER_PROOF)];
+
+			expect(() =>
+				KZG.verifyBlobKzgProofBatch(blobs, commitments, proofs),
+			).toThrow(KzgError);
+		});
 	});
 
 	describe("Trusted Setup", () => {

--- a/src/crypto/KZG/verifyBlobKzgProofBatch.js
+++ b/src/crypto/KZG/verifyBlobKzgProofBatch.js
@@ -1,3 +1,4 @@
+import { BYTES_PER_COMMITMENT, BYTES_PER_PROOF } from "./constants.js";
 import { KzgError, KzgNotInitializedError } from "./errors.js";
 import { getInitialized } from "./loadTrustedSetup.js";
 import { validateBlob } from "./validateBlob.js";
@@ -41,6 +42,51 @@ export function VerifyBlobKzgProofBatch({
 		}
 		for (const blob of blobs) {
 			validateBlob(blob);
+		}
+		for (let i = 0; i < commitments.length; i++) {
+			const commitment = commitments[i];
+			if (
+				!(commitment instanceof Uint8Array) ||
+				commitment.length !== BYTES_PER_COMMITMENT
+			) {
+				throw new KzgError(
+					`Commitment at index ${i} must be ${BYTES_PER_COMMITMENT} bytes, got ${commitment instanceof Uint8Array ? commitment.length : "not Uint8Array"}`,
+					{
+						code: "KZG_INVALID_COMMITMENT",
+						context: {
+							index: i,
+							commitmentType:
+								commitment instanceof Uint8Array
+									? "Uint8Array"
+									: typeof commitment,
+							commitmentLength:
+								commitment instanceof Uint8Array ? commitment.length : undefined,
+							expected: BYTES_PER_COMMITMENT,
+						},
+						docsPath: "/crypto/kzg/verify-blob-kzg-proof-batch#error-handling",
+					},
+				);
+			}
+		}
+		for (let i = 0; i < proofs.length; i++) {
+			const proof = proofs[i];
+			if (!(proof instanceof Uint8Array) || proof.length !== BYTES_PER_PROOF) {
+				throw new KzgError(
+					`Proof at index ${i} must be ${BYTES_PER_PROOF} bytes, got ${proof instanceof Uint8Array ? proof.length : "not Uint8Array"}`,
+					{
+						code: "KZG_INVALID_PROOF",
+						context: {
+							index: i,
+							proofType:
+								proof instanceof Uint8Array ? "Uint8Array" : typeof proof,
+							proofLength:
+								proof instanceof Uint8Array ? proof.length : undefined,
+							expected: BYTES_PER_PROOF,
+						},
+						docsPath: "/crypto/kzg/verify-blob-kzg-proof-batch#error-handling",
+					},
+				);
+			}
 		}
 		try {
 			return ckzgVerifyBlobKzgProofBatch(blobs, commitments, proofs);


### PR DESCRIPTION
## Summary
- Fixes #129
- Added validation in `verifyBlobKzgProofBatch` for proof and commitment sizes
- KZG proofs must be exactly 48 bytes (BLS12-381 G1 point)
- Rejects wrong-sized proofs/commitments with descriptive error messages

## Test plan
- [x] Added tests for invalid proof sizes (32 bytes instead of 48)
- [x] Added tests for zero-length proofs
- [x] Added tests for invalid commitment sizes
- [x] Added tests for non-Uint8Array inputs
- [x] Ran KZG tests - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)