### PR TITLE
fix: Preserve precision in Wei.toEther for large values

### DIFF
--- a/src/primitives/Denomination/wei-toEther.test.ts
+++ b/src/primitives/Denomination/wei-toEther.test.ts
@@ -39,4 +39,67 @@ describe("toEther", () => {
 		const ether = toEther(wei);
 		expect(ether).toBe("123");
 	});
+
+	// Issue #115: Precision tests for very large values
+	// These tests verify no floating point is used (pure bigint math)
+
+	it("preserves full precision for 1 wei (smallest unit)", () => {
+		const wei = from(1n);
+		const ether = toEther(wei);
+		expect(ether).toBe("0.000000000000000001");
+	});
+
+	it("preserves full 18 decimal precision", () => {
+		const wei = from(1234567890123456789n);
+		const ether = toEther(wei);
+		expect(ether).toBe("1.234567890123456789");
+	});
+
+	it("preserves precision for very large values (10^50 wei)", () => {
+		const wei = from(10n ** 50n);
+		const ether = toEther(wei);
+		// 10^50 wei = 10^32 ether (no decimal)
+		expect(ether).toBe("100000000000000000000000000000000");
+	});
+
+	it("preserves precision for max U256 value", () => {
+		const maxU256 = 2n ** 256n - 1n;
+		const wei = from(maxU256);
+		const ether = toEther(wei);
+		// Full precision: 115792089237316195423570985008687907853269984665640564039457.584007913129639935
+		expect(ether).toBe(
+			"115792089237316195423570985008687907853269984665640564039457.584007913129639935",
+		);
+	});
+
+	it("preserves precision for large value with full decimal precision", () => {
+		// 123456789012345678901234567890 wei
+		const wei = from(123456789012345678901234567890n);
+		const ether = toEther(wei);
+		expect(ether).toBe("123456789012.34567890123456789");
+	});
+
+	it("handles value just above 1 ether", () => {
+		const wei = from(WEI_PER_ETHER + 1n);
+		const ether = toEther(wei);
+		expect(ether).toBe("1.000000000000000001");
+	});
+
+	it("handles value just below 1 ether", () => {
+		const wei = from(WEI_PER_ETHER - 1n);
+		const ether = toEther(wei);
+		expect(ether).toBe("0.999999999999999999");
+	});
+
+	it("handles trailing zeros correctly", () => {
+		const wei = from(1_000_000_000_000_000_000_000n); // 1000 ETH
+		const ether = toEther(wei);
+		expect(ether).toBe("1000");
+	});
+
+	it("handles mixed precision correctly", () => {
+		const wei = from(1_500_000_000_000_000_001n); // 1.500000000000000001 ETH
+		const ether = toEther(wei);
+		expect(ether).toBe("1.500000000000000001");
+	});
 });

--- a/src/primitives/Denomination/wei-toEther.ts
+++ b/src/primitives/Denomination/wei-toEther.ts
@@ -7,17 +7,20 @@ const DECIMALS = 18;
  * Convert Wei to Ether
  *
  * Converts bigint wei to decimal string ether value.
+ * Uses pure string manipulation (no floating point) to preserve full precision
+ * for arbitrarily large values up to max U256.
  *
  * @see https://voltaire.tevm.sh/primitives/denomination for Denomination documentation
  * @since 0.0.0
  * @param wei - Amount in Wei (bigint)
- * @returns Amount in Ether (string with decimal precision)
+ * @returns Amount in Ether (string with decimal precision, 18 decimals max)
  * @throws {never}
  * @example
  * ```typescript
  * const ether1 = Wei.toEther(Wei.from(1000000000000000000n)); // "1"
  * const ether2 = Wei.toEther(Wei.from(1500000000000000000n)); // "1.5"
  * const ether3 = Wei.toEther(Wei.from(1000000000000000n));    // "0.001"
+ * const ether4 = Wei.toEther(Wei.from(1n));                   // "0.000000000000000001"
  * ```
  */
 export function toEther(wei: BrandedWei): BrandedEther {


### PR DESCRIPTION
## Summary
- Fixes #115
- Implementation already uses pure bigint/string math (no floating point)
- Added 9 comprehensive precision tests for very large values (up to max U256)
- Updated JSDoc to document precision guarantees

## Test plan
- [x] Added tests for 1 wei (smallest unit)
- [x] Added tests for max U256 value
- [x] Added tests for 10^50 wei
- [x] Added edge case tests (just above/below 1 ether)
- [x] Ran all Denomination tests (167 passed)

🤖 Generated with [Claude Code](https://claude.ai/code)