### PR TITLE
feat: Implement Address.IsContract factory for contract detection

### DIFF
--- a/src/primitives/Address/IsContract.js
+++ b/src/primitives/Address/IsContract.js
@@ -1,0 +1,48 @@
+import { toHex } from "./toHex.js";
+
+/**
+ * Factory: Check if an address is a contract (has deployed bytecode)
+ *
+ * @param {Object} deps - Provider dependencies
+ * @param {(address: string) => Promise<string>} deps.getCode - eth_getCode RPC call. Takes checksummed/lowercase hex address, returns hex bytecode or "0x"
+ * @returns {(address: import('./AddressType.js').AddressType) => Promise<boolean>} Async function that returns true if address has code
+ *
+ * @example
+ * ```typescript
+ * import { IsContract } from '@tevm/voltaire/Address'
+ * import { createPublicClient, http } from 'viem'
+ *
+ * const client = createPublicClient({ transport: http() })
+ * const isContract = IsContract({
+ *   getCode: (addr) => client.getCode({ address: addr })
+ * })
+ *
+ * const result = await isContract(address)
+ * // true if contract, false if EOA
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Using with ethers.js
+ * import { IsContract } from '@tevm/voltaire/Address'
+ * import { ethers } from 'ethers'
+ *
+ * const provider = new ethers.JsonRpcProvider('https://...')
+ * const isContract = IsContract({
+ *   getCode: (addr) => provider.getCode(addr)
+ * })
+ * ```
+ */
+export function IsContract({ getCode }) {
+	/**
+	 * Check if address has deployed bytecode
+	 * @param {import('./AddressType.js').AddressType} address - Address to check
+	 * @returns {Promise<boolean>} True if address has code (is a contract)
+	 */
+	return async function isContract(address) {
+		const hexAddress = toHex(address);
+		const code = await getCode(hexAddress);
+		// Contract if code exists and is more than "0x"
+		return code !== null && code !== undefined && code !== "0x" && code.length > 2;
+	};
+}

--- a/src/primitives/Address/IsContract.test.ts
+++ b/src/primitives/Address/IsContract.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { IsContract } from "./IsContract.js";
+import { from } from "./from.js";
+
+describe("IsContract", () => {
+	const testAddress = from("0x742d35Cc6634C0532925a3b844Bc454e4438f44e");
+
+	it("should return true when address has bytecode", async () => {
+		const mockGetCode = async (_addr: string) => "0x608060405234801561001057600080fd";
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(true);
+	});
+
+	it("should return false when address returns 0x (EOA)", async () => {
+		const mockGetCode = async (_addr: string) => "0x";
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(false);
+	});
+
+	it("should return false when address returns null", async () => {
+		const mockGetCode = async (_addr: string) => null as unknown as string;
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(false);
+	});
+
+	it("should return false when address returns undefined", async () => {
+		const mockGetCode = async (_addr: string) => undefined as unknown as string;
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(false);
+	});
+
+	it("should pass correct hex address to getCode", async () => {
+		let receivedAddress = "";
+		const mockGetCode = async (addr: string) => {
+			receivedAddress = addr;
+			return "0x";
+		};
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		await isContract(testAddress);
+		expect(receivedAddress).toBe("0x742d35cc6634c0532925a3b844bc454e4438f44e");
+	});
+
+	it("should handle minimal bytecode (just 0x00)", async () => {
+		const mockGetCode = async (_addr: string) => "0x00";
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(true);
+	});
+
+	it("should work with async getCode that resolves later", async () => {
+		const mockGetCode = async (_addr: string) => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			return "0x6080";
+		};
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		const result = await isContract(testAddress);
+		expect(result).toBe(true);
+	});
+
+	it("should propagate errors from getCode", async () => {
+		const mockGetCode = async (_addr: string): Promise<string> => {
+			throw new Error("RPC error");
+		};
+		const isContract = IsContract({ getCode: mockGetCode });
+
+		await expect(isContract(testAddress)).rejects.toThrow("RPC error");
+	});
+});

--- a/src/primitives/Address/index.ts
+++ b/src/primitives/Address/index.ts
@@ -307,6 +307,7 @@ Address.calculateCreate2Address = (
 Address.SIZE = BrandedAddress.SIZE;
 Address.assert = BrandedAddress.assert;
 Address.Assert = BrandedAddress.Assert;
+Address.IsContract = BrandedAddress.IsContract;
 
 // Set up Address.prototype to inherit from Uint8Array.prototype
 Object.setPrototypeOf(Address.prototype, Uint8Array.prototype);

--- a/src/primitives/Address/internal-index.ts
+++ b/src/primitives/Address/internal-index.ts
@@ -14,6 +14,7 @@ export { CalculateCreate2Address } from "./calculateCreate2Address.js";
 export { CalculateCreateAddress } from "./calculateCreateAddress.js";
 export { FromPrivateKey } from "./fromPrivateKey.js";
 export { FromPublicKey } from "./fromPublicKey.js";
+export { IsContract } from "./IsContract.js";
 export { IsValidChecksum } from "./isValidChecksum.js";
 // Export factory functions from wrappers
 export { ToChecksummed } from "./toChecksummed.js";
@@ -26,6 +27,7 @@ import { CalculateCreate2Address as CalculateCreate2AddressFactory } from "./cal
 import { CalculateCreateAddress as CalculateCreateAddressFactory } from "./calculateCreateAddress.js";
 import { FromPrivateKey as FromPrivateKeyFactory } from "./fromPrivateKey.js";
 import { FromPublicKey as FromPublicKeyFactory } from "./fromPublicKey.js";
+import { IsContract as IsContractFactory } from "./IsContract.js";
 import { IsValidChecksum as IsValidChecksumFactory } from "./isValidChecksum.js";
 import { ToChecksummed as ToChecksummedFactory } from "./toChecksummed.js";
 
@@ -178,6 +180,7 @@ export const BrandedAddress = {
 	isValid,
 	isValidChecksum,
 	IsValidChecksum: IsValidChecksumFactory,
+	IsContract: IsContractFactory,
 	is,
 	zero,
 	clone,


### PR DESCRIPTION
## Summary
- Fixes #114
- Adds `Address.IsContract` factory that accepts `getCode` function
- Returns `true` for addresses with code (contracts), `false` for EOAs
- Works with any provider (viem, ethers, raw RPC)

## Test plan
- [x] Added tests with mock getCode (8 test cases)
- [x] Tests cover: contracts, EOAs, null/undefined, error propagation
- [x] Ran Address tests (886 passing)

🤖 Generated with [Claude Code](https://claude.ai/code)