### PR TITLE
feat: Add ChainId.isKnown() and strict validation

### DIFF
--- a/src/primitives/ChainId/fromStrict.js
+++ b/src/primitives/ChainId/fromStrict.js
@@ -1,0 +1,51 @@
+import { ValidationError } from "../errors/ValidationError.js";
+import { from } from "./from.js";
+import { KNOWN_CHAINS, CHAIN_NAMES } from "./knownChains.js";
+
+/**
+ * Create ChainId from number with strict validation
+ * Warns or throws for unknown chain IDs
+ *
+ * @param {number} value - Chain ID number
+ * @param {{ mode?: 'warn' | 'throw' }} [options] - Validation options
+ * @returns {import('./ChainIdType.js').ChainIdType} Branded chain ID
+ * @throws {ValidationError} If mode is 'throw' and chain ID is unknown
+ *
+ * @example
+ * ```typescript
+ * // Warn mode (default) - logs warning but returns value
+ * const chain = ChainId.fromStrict(999999); // logs warning
+ *
+ * // Throw mode - throws for unknown chains
+ * const chain = ChainId.fromStrict(999999, { mode: 'throw' }); // throws
+ *
+ * // Known chains work normally
+ * const mainnet = ChainId.fromStrict(1); // no warning
+ * ```
+ */
+export function fromStrict(value, options = {}) {
+	const chainId = from(value);
+	const mode = options.mode ?? "warn";
+
+	if (!KNOWN_CHAINS.has(value)) {
+		const knownList = Array.from(CHAIN_NAMES.entries())
+			.map(([id, name]) => `${id} (${name})`)
+			.join(", ");
+
+		const message = `Unknown chain ID: ${value}. Known chains: ${knownList}`;
+
+		if (mode === "throw") {
+			throw new ValidationError(message, {
+				value,
+				expected: `One of: ${knownList}`,
+				code: "CHAIN_ID_UNKNOWN",
+				docsPath: "/primitives/chain-id/from-strict#error-handling",
+			});
+		}
+
+		// Warn mode
+		console.warn(`[ChainId] ${message}`);
+	}
+
+	return chainId;
+}

--- a/src/primitives/ChainId/fromStrict.test.ts
+++ b/src/primitives/ChainId/fromStrict.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { ValidationError } from "../errors/ValidationError.js";
+import * as ChainId from "./index.js";
+
+describe("fromStrict", () => {
+	it("returns chain ID for known chains without warning", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const mainnet = ChainId.fromStrict(1);
+		expect(mainnet).toBe(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+
+		warnSpy.mockRestore();
+	});
+
+	it("warns for unknown chains in warn mode (default)", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const unknown = ChainId.fromStrict(999999);
+		expect(unknown).toBe(999999);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Unknown chain ID: 999999"),
+		);
+
+		warnSpy.mockRestore();
+	});
+
+	it("warns for unknown chains in explicit warn mode", () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+		const unknown = ChainId.fromStrict(12345, { mode: "warn" });
+		expect(unknown).toBe(12345);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining("Unknown chain ID: 12345"),
+		);
+
+		warnSpy.mockRestore();
+	});
+
+	it("throws for unknown chains in throw mode", () => {
+		expect(() => ChainId.fromStrict(999999, { mode: "throw" })).toThrow(
+			ValidationError,
+		);
+		expect(() => ChainId.fromStrict(999999, { mode: "throw" })).toThrow(
+			"Unknown chain ID: 999999",
+		);
+	});
+
+	it("does not throw for known chains in throw mode", () => {
+		expect(() => ChainId.fromStrict(1, { mode: "throw" })).not.toThrow();
+		expect(() =>
+			ChainId.fromStrict(ChainId.POLYGON, { mode: "throw" }),
+		).not.toThrow();
+	});
+
+	it("still validates format (rejects negative)", () => {
+		expect(() => ChainId.fromStrict(-1)).toThrow();
+	});
+
+	it("still validates format (rejects non-integer)", () => {
+		expect(() => ChainId.fromStrict(1.5)).toThrow();
+	});
+});

--- a/src/primitives/ChainId/getName.js
+++ b/src/primitives/ChainId/getName.js
@@ -1,0 +1,20 @@
+import { CHAIN_NAMES } from "./knownChains.js";
+
+/**
+ * Get human-readable name for a chain ID
+ *
+ * @this {import('./ChainIdType.js').ChainIdType}
+ * @returns {string | undefined} Chain name or undefined if unknown
+ *
+ * @example
+ * ```typescript
+ * import * as ChainId from './index.js';
+ *
+ * ChainId.getName(1);        // "Mainnet"
+ * ChainId.getName(137);      // "Polygon"
+ * ChainId.getName(999999);   // undefined
+ * ```
+ */
+export function getName() {
+	return CHAIN_NAMES.get(/** @type {number} */ (this));
+}

--- a/src/primitives/ChainId/getName.test.ts
+++ b/src/primitives/ChainId/getName.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as ChainId from "./index.js";
+
+describe("getName", () => {
+	it("returns name for mainnet", () => {
+		expect(ChainId.getName(1)).toBe("Mainnet");
+	});
+
+	it("returns names for all known chains", () => {
+		expect(ChainId.getName(ChainId.MAINNET)).toBe("Mainnet");
+		expect(ChainId.getName(ChainId.GOERLI)).toBe("Goerli");
+		expect(ChainId.getName(ChainId.SEPOLIA)).toBe("Sepolia");
+		expect(ChainId.getName(ChainId.HOLESKY)).toBe("Holesky");
+		expect(ChainId.getName(ChainId.OPTIMISM)).toBe("Optimism");
+		expect(ChainId.getName(ChainId.ARBITRUM)).toBe("Arbitrum One");
+		expect(ChainId.getName(ChainId.BASE)).toBe("Base");
+		expect(ChainId.getName(ChainId.POLYGON)).toBe("Polygon");
+	});
+
+	it("returns undefined for unknown chain IDs", () => {
+		expect(ChainId.getName(999999)).toBeUndefined();
+		expect(ChainId.getName(12345)).toBeUndefined();
+		expect(ChainId.getName(0)).toBeUndefined();
+	});
+
+	it("works with internal function", () => {
+		const chainId = ChainId.from(137);
+		expect(ChainId._getName.call(chainId)).toBe("Polygon");
+	});
+});

--- a/src/primitives/ChainId/index.ts
+++ b/src/primitives/ChainId/index.ts
@@ -13,14 +13,20 @@ export {
 	SEPOLIA,
 } from "./constants.js";
 
+// Export known chains data
+export { KNOWN_CHAINS, CHAIN_NAMES } from "./knownChains.js";
+
 import { equals as _equals } from "./equals.js";
 // Import all functions
 import { from } from "./from.js";
+import { fromStrict } from "./fromStrict.js";
+import { getName as _getName } from "./getName.js";
+import { isKnown as _isKnown } from "./isKnown.js";
 import { isMainnet as _isMainnet } from "./isMainnet.js";
 import { toNumber as _toNumber } from "./toNumber.js";
 
 // Export constructors
-export { from };
+export { from, fromStrict };
 
 // Export public wrapper functions
 export function toNumber(chainId: number): number {
@@ -35,13 +41,24 @@ export function isMainnet(chainId: number): boolean {
 	return _isMainnet.call(from(chainId));
 }
 
+export function isKnown(chainId: number): boolean {
+	return _isKnown.call(from(chainId));
+}
+
+export function getName(chainId: number): string | undefined {
+	return _getName.call(from(chainId));
+}
+
 // Export internal functions (tree-shakeable)
-export { _toNumber, _equals, _isMainnet };
+export { _toNumber, _equals, _isMainnet, _isKnown, _getName };
 
 // Export as namespace (convenience)
 export const ChainId = {
 	from,
+	fromStrict,
 	toNumber,
 	equals,
 	isMainnet,
+	isKnown,
+	getName,
 };

--- a/src/primitives/ChainId/isKnown.js
+++ b/src/primitives/ChainId/isKnown.js
@@ -1,0 +1,20 @@
+import { KNOWN_CHAINS } from "./knownChains.js";
+
+/**
+ * Check if chain ID is a known/supported chain
+ *
+ * @this {import('./ChainIdType.js').ChainIdType}
+ * @returns {boolean} True if chain ID is known
+ *
+ * @example
+ * ```typescript
+ * import * as ChainId from './index.js';
+ *
+ * ChainId.isKnown(1);        // true (Mainnet)
+ * ChainId.isKnown(137);      // true (Polygon)
+ * ChainId.isKnown(999999);   // false (unknown)
+ * ```
+ */
+export function isKnown() {
+	return KNOWN_CHAINS.has(/** @type {number} */ (this));
+}

--- a/src/primitives/ChainId/isKnown.test.ts
+++ b/src/primitives/ChainId/isKnown.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as ChainId from "./index.js";
+
+describe("isKnown", () => {
+	it("returns true for mainnet", () => {
+		expect(ChainId.isKnown(1)).toBe(true);
+	});
+
+	it("returns true for all known chains", () => {
+		expect(ChainId.isKnown(ChainId.MAINNET)).toBe(true);
+		expect(ChainId.isKnown(ChainId.GOERLI)).toBe(true);
+		expect(ChainId.isKnown(ChainId.SEPOLIA)).toBe(true);
+		expect(ChainId.isKnown(ChainId.HOLESKY)).toBe(true);
+		expect(ChainId.isKnown(ChainId.OPTIMISM)).toBe(true);
+		expect(ChainId.isKnown(ChainId.ARBITRUM)).toBe(true);
+		expect(ChainId.isKnown(ChainId.BASE)).toBe(true);
+		expect(ChainId.isKnown(ChainId.POLYGON)).toBe(true);
+	});
+
+	it("returns false for unknown chain IDs", () => {
+		expect(ChainId.isKnown(999999)).toBe(false);
+		expect(ChainId.isKnown(12345)).toBe(false);
+		expect(ChainId.isKnown(0)).toBe(false);
+	});
+
+	it("works with internal function", () => {
+		const chainId = ChainId.from(1);
+		expect(ChainId._isKnown.call(chainId)).toBe(true);
+	});
+});

--- a/src/primitives/ChainId/knownChains.js
+++ b/src/primitives/ChainId/knownChains.js
@@ -1,0 +1,40 @@
+import {
+	MAINNET,
+	GOERLI,
+	SEPOLIA,
+	HOLESKY,
+	OPTIMISM,
+	ARBITRUM,
+	BASE,
+	POLYGON,
+} from "./constants.js";
+
+/**
+ * Set of known/supported chain IDs
+ * @type {Set<number>}
+ */
+export const KNOWN_CHAINS = new Set([
+	MAINNET,
+	GOERLI,
+	SEPOLIA,
+	HOLESKY,
+	OPTIMISM,
+	ARBITRUM,
+	BASE,
+	POLYGON,
+]);
+
+/**
+ * Map of chain IDs to human-readable names
+ * @type {Map<number, string>}
+ */
+export const CHAIN_NAMES = new Map([
+	[MAINNET, "Mainnet"],
+	[GOERLI, "Goerli"],
+	[SEPOLIA, "Sepolia"],
+	[HOLESKY, "Holesky"],
+	[OPTIMISM, "Optimism"],
+	[ARBITRUM, "Arbitrum One"],
+	[BASE, "Base"],
+	[POLYGON, "Polygon"],
+]);

--- a/src/primitives/ChainId/knownChains.test.ts
+++ b/src/primitives/ChainId/knownChains.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import * as ChainId from "./index.js";
+
+describe("KNOWN_CHAINS", () => {
+	it("contains all expected chains", () => {
+		expect(ChainId.KNOWN_CHAINS.has(1)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(5)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(10)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(137)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(8453)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(42161)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(11155111)).toBe(true);
+		expect(ChainId.KNOWN_CHAINS.has(17000)).toBe(true);
+	});
+
+	it("has correct size", () => {
+		expect(ChainId.KNOWN_CHAINS.size).toBe(8);
+	});
+});
+
+describe("CHAIN_NAMES", () => {
+	it("maps chain IDs to names", () => {
+		expect(ChainId.CHAIN_NAMES.get(1)).toBe("Mainnet");
+		expect(ChainId.CHAIN_NAMES.get(10)).toBe("Optimism");
+		expect(ChainId.CHAIN_NAMES.get(137)).toBe("Polygon");
+	});
+
+	it("has same size as KNOWN_CHAINS", () => {
+		expect(ChainId.CHAIN_NAMES.size).toBe(ChainId.KNOWN_CHAINS.size);
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #113
- Adds `ChainId.isKnown()` to check against known chain IDs
- Adds `ChainId.fromStrict()` with warn/throw modes for unknown chains
- Adds `ChainId.getName()` for human-readable chain names
- Exports `KNOWN_CHAINS` Set and `CHAIN_NAMES` Map for direct access

## New API

```typescript
import * as ChainId from '@tevm/voltaire';

// Check if known
ChainId.isKnown(1);      // true (Mainnet)
ChainId.isKnown(999999); // false

// Get name
ChainId.getName(137);    // "Polygon"
ChainId.getName(999999); // undefined

// Strict mode (warn by default)
ChainId.fromStrict(999999); // logs warning, returns value

// Strict mode (throw)
ChainId.fromStrict(999999, { mode: 'throw' }); // throws ValidationError
```

## Test plan
- [x] Added tests for `isKnown()`
- [x] Added tests for `getName()`
- [x] Added tests for `fromStrict()` warn mode
- [x] Added tests for `fromStrict()` throw mode
- [x] Added tests for `knownChains` exports
- [x] All ChainId tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)