### PR TITLE
fix: Verify bloom filter has no false negatives

### DIFF
--- a/src/primitives/BloomFilter/no-false-negatives.test.ts
+++ b/src/primitives/BloomFilter/no-false-negatives.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+import { BITS, DEFAULT_HASH_COUNT } from "./constants.js";
+import * as BloomFilter from "./index.js";
+
+/**
+ * This test file verifies that the bloom filter implementation
+ * never produces false negatives. A bloom filter should only
+ * have false positives (claiming something is present when it isn't),
+ * never false negatives (claiming something is absent when it is present).
+ *
+ * If any of these tests fail, it indicates a critical bug in the
+ * bloom filter implementation that would cause log filtering to
+ * incorrectly reject matching logs.
+ *
+ * See: https://github.com/tevm/voltaire/issues/110
+ */
+describe("BloomFilter - No False Negatives Guarantee", () => {
+	it("verifies no false negatives with 1000 random items", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// Generate 1000 random items
+		for (let i = 0; i < 1000; i++) {
+			const item = new Uint8Array(32);
+			for (let j = 0; j < 32; j++) {
+				item[j] = Math.floor(Math.random() * 256);
+			}
+			items.push(item);
+			BloomFilter.add(filter, item);
+		}
+
+		// Every item that was added MUST be found
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with sequential 20-byte addresses", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const addresses: Uint8Array[] = [];
+
+		// Generate 500 sequential addresses (simulating Ethereum addresses)
+		for (let i = 0; i < 500; i++) {
+			const addr = new Uint8Array(20);
+			// Set last 4 bytes as counter
+			addr[16] = (i >> 24) & 0xff;
+			addr[17] = (i >> 16) & 0xff;
+			addr[18] = (i >> 8) & 0xff;
+			addr[19] = i & 0xff;
+			addresses.push(addr);
+			BloomFilter.add(filter, addr);
+		}
+
+		// Every address that was added MUST be found
+		for (let i = 0; i < addresses.length; i++) {
+			const found = BloomFilter.contains(filter, addresses[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with sequential 32-byte topics", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const topics: Uint8Array[] = [];
+
+		// Generate 500 sequential topics (simulating event topics)
+		for (let i = 0; i < 500; i++) {
+			const topic = new Uint8Array(32);
+			// Set last 4 bytes as counter
+			topic[28] = (i >> 24) & 0xff;
+			topic[29] = (i >> 16) & 0xff;
+			topic[30] = (i >> 8) & 0xff;
+			topic[31] = i & 0xff;
+			topics.push(topic);
+			BloomFilter.add(filter, topic);
+		}
+
+		// Every topic that was added MUST be found
+		for (let i = 0; i < topics.length; i++) {
+			const found = BloomFilter.contains(filter, topics[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with mixed address and topic data", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// Simulate a real log filter scenario with address + multiple topics
+		for (let log = 0; log < 100; log++) {
+			// Address (20 bytes)
+			const addr = new Uint8Array(20);
+			addr[19] = log;
+			items.push(addr);
+			BloomFilter.add(filter, addr);
+
+			// Topic0 - event signature (32 bytes)
+			const topic0 = new Uint8Array(32);
+			topic0[0] = 0xdd;
+			topic0[1] = 0xf2;
+			topic0[31] = log;
+			items.push(topic0);
+			BloomFilter.add(filter, topic0);
+
+			// Topic1 - indexed param (32 bytes)
+			const topic1 = new Uint8Array(32);
+			topic1[12] = log;
+			items.push(topic1);
+			BloomFilter.add(filter, topic1);
+		}
+
+		// Every item that was added MUST be found
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives after serialization round-trip", () => {
+		const original = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// Add items to original filter
+		for (let i = 0; i < 200; i++) {
+			const item = new Uint8Array(32);
+			item[31] = i & 0xff;
+			item[30] = (i >> 8) & 0xff;
+			items.push(item);
+			BloomFilter.add(original, item);
+		}
+
+		// Serialize and deserialize
+		const hex = BloomFilter.toHex(original);
+		const restored = BloomFilter.fromHex(hex, BITS, DEFAULT_HASH_COUNT);
+
+		// Every item that was added MUST be found in restored filter
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(restored, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives after merge operation", () => {
+		const filter1 = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const filter2 = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items1: Uint8Array[] = [];
+		const items2: Uint8Array[] = [];
+
+		// Add items to filter1
+		for (let i = 0; i < 100; i++) {
+			const item = new Uint8Array(20);
+			item[19] = i;
+			items1.push(item);
+			BloomFilter.add(filter1, item);
+		}
+
+		// Add different items to filter2
+		for (let i = 100; i < 200; i++) {
+			const item = new Uint8Array(20);
+			item[19] = i;
+			items2.push(item);
+			BloomFilter.add(filter2, item);
+		}
+
+		// Merge filters
+		const merged = BloomFilter.merge(filter1, filter2);
+
+		// All items from both filters MUST be found in merged
+		for (const item of items1) {
+			expect(BloomFilter.contains(merged, item)).toBe(true);
+		}
+		for (const item of items2) {
+			expect(BloomFilter.contains(merged, item)).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with empty items", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const empty = new Uint8Array(0);
+
+		BloomFilter.add(filter, empty);
+		expect(BloomFilter.contains(filter, empty)).toBe(true);
+	});
+
+	it("verifies no false negatives with single-byte items", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// All possible single-byte values
+		for (let i = 0; i < 256; i++) {
+			const item = new Uint8Array([i]);
+			items.push(item);
+			BloomFilter.add(filter, item);
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with very long items", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// Items of various large sizes
+		for (let size = 100; size <= 1000; size += 100) {
+			const item = new Uint8Array(size);
+			for (let j = 0; j < size; j++) {
+				item[j] = (j * 7) % 256;
+			}
+			items.push(item);
+			BloomFilter.add(filter, item);
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with items containing all zeros", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// All-zero items of different sizes
+		for (let size = 1; size <= 64; size++) {
+			const item = new Uint8Array(size);
+			items.push(item);
+			BloomFilter.add(filter, item);
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with items containing all 0xFF", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const items: Uint8Array[] = [];
+
+		// All-0xFF items of different sizes
+		for (let size = 1; size <= 64; size++) {
+			const item = new Uint8Array(size).fill(0xff);
+			items.push(item);
+			BloomFilter.add(filter, item);
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+			expect(found).toBe(true);
+		}
+	});
+
+	it("verifies no false negatives with repeated adds", () => {
+		const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+		const item = new Uint8Array([1, 2, 3, 4, 5]);
+
+		// Add same item multiple times
+		for (let i = 0; i < 100; i++) {
+			BloomFilter.add(filter, item);
+		}
+
+		// Must still be found
+		expect(BloomFilter.contains(filter, item)).toBe(true);
+	});
+
+	it("maintains no false negatives property under stress", () => {
+		// Create multiple filters and verify property holds
+		for (let run = 0; run < 10; run++) {
+			const filter = BloomFilter.create(BITS, DEFAULT_HASH_COUNT);
+			const items: Uint8Array[] = [];
+
+			// Add random items
+			const count = 50 + Math.floor(Math.random() * 100);
+			for (let i = 0; i < count; i++) {
+				const size = 1 + Math.floor(Math.random() * 64);
+				const item = new Uint8Array(size);
+				for (let j = 0; j < size; j++) {
+					item[j] = Math.floor(Math.random() * 256);
+				}
+				items.push(item);
+				BloomFilter.add(filter, item);
+			}
+
+			// Verify all items are found
+			for (let i = 0; i < items.length; i++) {
+				const found = BloomFilter.contains(filter, items[i] as Uint8Array);
+				expect(found).toBe(true);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #110
- Added comprehensive test suite to verify BloomFilter implementation never produces false negatives
- Tests cover: 1000 random items, sequential addresses, topics, serialization round-trip, merge operations, edge cases, stress testing

## Investigation

The issue mentioned `src/primitives/Filter/matches.js` which doesn't exist. The actual relevant code is:
- `src/primitives/BloomFilter/` - Bloom filter implementation
- `src/primitives/LogFilter/matches.js` - Log filter matching (doesn't use bloom filter directly)

The BloomFilter implementation was analyzed and confirmed correct:
- `add()` correctly sets bits using `filter[idx] = byte | (1 << bit)`
- `contains()` correctly checks bits using `(byte & (1 << bit)) === 0`

Both use the same `hash()` function, ensuring consistent bit positions.

## Test plan
- [x] Added 13 tests verifying no false negatives in various scenarios
- [x] Ran BloomFilter tests - all pass
- [x] Verified implementation is mathematically correct

🤖 Generated with [Claude Code](https://claude.ai/code)