### PR TITLE
fix: Handle PoS blocks in Block.calculateHash()

### DIFF
--- a/src/primitives/BlockHeader/BlockHeader.test.ts
+++ b/src/primitives/BlockHeader/BlockHeader.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { toBytes } from "../Hex/toBytes.js";
 import * as BlockHeader from "./index.js";
 
 describe("BlockHeader", () => {
@@ -109,6 +110,116 @@ describe("BlockHeader", () => {
 			expect(header.gasLimit).toBe(30000000n);
 			expect(header.gasUsed).toBe(21000n);
 			expect(header.timestamp).toBe(1234567890n);
+		});
+	});
+
+	describe("calculateHash", () => {
+		// Real mainnet block 20,000,000 (PoS, Cancun fork)
+		// https://etherscan.io/block/20000000
+		const block20000000 = {
+			parentHash:
+				"0xb390d63aac03bbef75de888d16bd56b91c9291c2a7e38d36ac24731351522bd1",
+			// Empty uncles hash (PoS)
+			ommersHash:
+				"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+			beneficiary: "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5",
+			stateRoot:
+				"0x68421c2c599dc31396a09772a073fb421c4bd25ef1462914ef13e5dfa2d31c23",
+			transactionsRoot:
+				"0xf0280ae7fd02f2b9684be8d740830710cd62e4869c891c3a0ead32ea757e70a3",
+			receiptsRoot:
+				"0xb39f9f7a13a342751bd2c575eca303e224393d4e11d715866b114b7e824da608",
+			logsBloom: toBytes(
+				"0x94a9480614840b245a1a2148e2100e2070472151b44c3020280930809a20c011609520bc10080074a61c782411e34713ee19c560ca02208f4770080013bc5d302d84743dd0008c5d089d5b1c95940de80809888ba7ed68512d426c048934c8cc0a08dd440b461265001ee50909a26d0213000a7411242c72a648c87e104c0097a0aaba477628508533c5924867341dd11305aa372350b019244034dc849419968b00fd2dda39ecff042639c43923f0d48495d2a40468524bce13a86444c82071ca9c431208870b33f5320f680f3991c2349e2433c80440b0832016820e1070a4405aadcc40050a5006c24504f0098c4391e0f04047c824d1d88ca8021d240510",
+			),
+			difficulty: 0n, // PoS
+			number: 20000000n, // 0x1312d00
+			gasLimit: 30000000n, // 0x1c9c380
+			gasUsed: 11089692n, // 0xa9371c
+			timestamp: 1717281407n, // 0x665ba27f
+			extraData: toBytes("0x6265617665726275696c642e6f7267"), // "beaverbuild.org"
+			mixHash:
+				"0x85175443c2889afcb52288e0fa8804b671e582f9fd416071a70642d90c7dc0db",
+			nonce: toBytes("0x0000000000000000"), // PoS nonce is 0
+			baseFeePerGas: 4936957716n, // 0x12643ff14
+			withdrawalsRoot:
+				"0xf0747de0368fb967ede9b81320a5b01a4d85b3d427e8bc8e96ff371478d80e76",
+			blobGasUsed: 131072n, // 0x20000
+			excessBlobGas: 0n,
+			parentBeaconBlockRoot:
+				"0xec0befcffe8b2792fc5e7b67dac85ee3bbb09bc56b0ea5d9a698ec3b402d296f",
+		};
+
+		const expectedHash20000000 =
+			"0xd24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183";
+
+		it("calculates hash for PoS block (Cancun fork, block 20,000,000)", () => {
+			const header = BlockHeader.from(block20000000);
+			const hash = BlockHeader.calculateHash(header);
+
+			// Convert to hex for comparison
+			const hashHex =
+				"0x" +
+				Array.from(hash)
+					.map((b) => b.toString(16).padStart(2, "0"))
+					.join("");
+
+			expect(hashHex).toBe(expectedHash20000000);
+		});
+
+		it("produces consistent RLP encoding", () => {
+			const header = BlockHeader.from(block20000000);
+			const rlp = BlockHeader.toRlp(header);
+
+			// RLP should be non-empty
+			expect(rlp.length).toBeGreaterThan(0);
+
+			// First byte should indicate a list (0xf8 or 0xf9 for long lists)
+			expect(rlp[0]).toBeGreaterThanOrEqual(0xf8);
+		});
+
+		it("handles PoS blocks (difficulty=0, nonce=0)", () => {
+			const header = BlockHeader.from({
+				...validHeader,
+				difficulty: 0n,
+				nonce: new Uint8Array(8), // All zeros
+				baseFeePerGas: 1000000000n,
+			});
+
+			const hash = BlockHeader.calculateHash(header);
+			expect(hash).toHaveLength(32);
+		});
+
+		it("handles pre-merge PoW blocks (no optional fields)", () => {
+			const header = BlockHeader.from({
+				...validHeader,
+				difficulty: 12345678901234n, // Non-zero difficulty
+				nonce: new Uint8Array([0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0]),
+			});
+
+			const hash = BlockHeader.calculateHash(header);
+			expect(hash).toHaveLength(32);
+		});
+
+		it("handles London fork blocks (with baseFeePerGas)", () => {
+			const header = BlockHeader.from({
+				...validHeader,
+				baseFeePerGas: 7n,
+			});
+
+			const hash = BlockHeader.calculateHash(header);
+			expect(hash).toHaveLength(32);
+		});
+
+		it("handles Shanghai fork blocks (with withdrawalsRoot)", () => {
+			const header = BlockHeader.from({
+				...validHeader,
+				baseFeePerGas: 7n,
+				withdrawalsRoot: new Uint8Array(32).fill(0xab),
+			});
+
+			const hash = BlockHeader.calculateHash(header);
+			expect(hash).toHaveLength(32);
 		});
 	});
 });

--- a/src/primitives/BlockHeader/calculateHash.js
+++ b/src/primitives/BlockHeader/calculateHash.js
@@ -1,0 +1,58 @@
+import { hash as keccak256 } from "../../crypto/Keccak256/hash.js";
+import { toRlp } from "./toRlp.js";
+
+/**
+ * Factory: Calculate block hash (keccak256 of RLP-encoded header)
+ *
+ * @param {Object} deps - Crypto dependencies
+ * @param {(data: Uint8Array) => Uint8Array} deps.keccak256 - Keccak256 hash function
+ * @returns {(header: import('./BlockHeaderType.js').BlockHeaderType) => import('../BlockHash/BlockHashType.js').BlockHashType} Function that calculates block hash
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-header for BlockHeader documentation
+ * @since 0.1.42
+ * @throws {never}
+ *
+ * Block hash is calculated as: keccak256(RLP(header))
+ * Works for both PoW (pre-merge) and PoS (post-merge) blocks.
+ * For PoS blocks, difficulty=0 and nonce=0x0000000000000000.
+ *
+ * @example
+ * ```javascript
+ * import { CalculateHash } from './primitives/BlockHeader/calculateHash.js';
+ * import { hash as keccak256 } from '../../crypto/Keccak256/hash.js';
+ * const calculateHash = CalculateHash({ keccak256 });
+ * const blockHash = calculateHash(blockHeader);
+ * ```
+ */
+export function CalculateHash({ keccak256 }) {
+	/**
+	 * @param {import('./BlockHeaderType.js').BlockHeaderType} header
+	 * @returns {import('../BlockHash/BlockHashType.js').BlockHashType}
+	 */
+	return function calculateHash(header) {
+		const rlpEncoded = toRlp(header);
+		return /** @type {import('../BlockHash/BlockHashType.js').BlockHashType} */ (
+			keccak256(rlpEncoded)
+		);
+	};
+}
+
+/**
+ * Calculate block hash (keccak256 of RLP-encoded header)
+ *
+ * Default export with crypto injected.
+ *
+ * @param {import('./BlockHeaderType.js').BlockHeaderType} header - Block header
+ * @returns {import('../BlockHash/BlockHashType.js').BlockHashType} Block hash (32 bytes)
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-header for BlockHeader documentation
+ * @since 0.1.42
+ * @throws {never}
+ *
+ * @example
+ * ```javascript
+ * import { calculateHash } from './primitives/BlockHeader/calculateHash.js';
+ * const blockHash = calculateHash(blockHeader);
+ * ```
+ */
+export const calculateHash = CalculateHash({ keccak256 });

--- a/src/primitives/BlockHeader/index.ts
+++ b/src/primitives/BlockHeader/index.ts
@@ -2,10 +2,12 @@
 export type { BlockHeaderType } from "./BlockHeaderType.js";
 
 // Import internal functions
+import { calculateHash as _calculateHash } from "./calculateHash.js";
 import { from as _from } from "./from.js";
+import { toRlp as _toRlp } from "./toRlp.js";
 
 // Export internal functions (tree-shakeable)
-export { _from };
+export { _calculateHash, _from, _toRlp };
 
 // Export public functions
 export function from(params: {
@@ -33,7 +35,21 @@ export function from(params: {
 	return _from(params as Parameters<typeof _from>[0]);
 }
 
+// Public calculateHash wrapper
+import type { BlockHeaderType } from "./BlockHeaderType.js";
+import type { BlockHashType } from "../BlockHash/BlockHashType.js";
+
+export function calculateHash(header: BlockHeaderType): BlockHashType {
+	return _calculateHash(header);
+}
+
+export function toRlp(header: BlockHeaderType): Uint8Array {
+	return _toRlp(header);
+}
+
 // Namespace export
 export const BlockHeader = {
 	from,
+	calculateHash,
+	toRlp,
 };

--- a/src/primitives/BlockHeader/toRlp.js
+++ b/src/primitives/BlockHeader/toRlp.js
@@ -1,0 +1,79 @@
+import { encode } from "../Rlp/encode.js";
+import { encodeBigintCompact } from "../Transaction/utils.js";
+
+/**
+ * Serialize BlockHeader to RLP-encoded bytes
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-header for BlockHeader documentation
+ * @since 0.1.42
+ * @param {import('./BlockHeaderType.js').BlockHeaderType} header - Block header to encode
+ * @returns {Uint8Array} RLP-encoded block header
+ * @throws {never}
+ *
+ * RLP encoding order (Ethereum Yellow Paper):
+ * 1. parentHash (32 bytes)
+ * 2. ommersHash (32 bytes)
+ * 3. beneficiary (20 bytes)
+ * 4. stateRoot (32 bytes)
+ * 5. transactionsRoot (32 bytes)
+ * 6. receiptsRoot (32 bytes)
+ * 7. logsBloom (256 bytes)
+ * 8. difficulty (bigint, compact)
+ * 9. number (bigint, compact)
+ * 10. gasLimit (bigint, compact)
+ * 11. gasUsed (bigint, compact)
+ * 12. timestamp (bigint, compact)
+ * 13. extraData (bytes)
+ * 14. mixHash (32 bytes)
+ * 15. nonce (8 bytes)
+ * 16. baseFeePerGas (optional, EIP-1559)
+ * 17. withdrawalsRoot (optional, Shanghai)
+ * 18. blobGasUsed (optional, Cancun)
+ * 19. excessBlobGas (optional, Cancun)
+ * 20. parentBeaconBlockRoot (optional, Cancun)
+ *
+ * @example
+ * ```javascript
+ * import { toRlp } from './primitives/BlockHeader/toRlp.js';
+ * const rlpBytes = toRlp(blockHeader);
+ * ```
+ */
+export function toRlp(header) {
+	/** @type {(Uint8Array)[]} */
+	const fields = [
+		header.parentHash,
+		header.ommersHash,
+		header.beneficiary,
+		header.stateRoot,
+		header.transactionsRoot,
+		header.receiptsRoot,
+		header.logsBloom,
+		encodeBigintCompact(header.difficulty),
+		encodeBigintCompact(header.number),
+		encodeBigintCompact(header.gasLimit),
+		encodeBigintCompact(header.gasUsed),
+		encodeBigintCompact(header.timestamp),
+		header.extraData,
+		header.mixHash,
+		header.nonce,
+	];
+
+	// Add optional fields in order (must be contiguous from first defined)
+	if (header.baseFeePerGas !== undefined) {
+		fields.push(encodeBigintCompact(header.baseFeePerGas));
+	}
+	if (header.withdrawalsRoot !== undefined) {
+		fields.push(header.withdrawalsRoot);
+	}
+	if (header.blobGasUsed !== undefined) {
+		fields.push(encodeBigintCompact(header.blobGasUsed));
+	}
+	if (header.excessBlobGas !== undefined) {
+		fields.push(encodeBigintCompact(header.excessBlobGas));
+	}
+	if (header.parentBeaconBlockRoot !== undefined) {
+		fields.push(header.parentBeaconBlockRoot);
+	}
+
+	return encode(fields);
+}


### PR DESCRIPTION
## Summary
- Fixes #103
- Adds `BlockHeader.calculateHash()` function that computes block hash from header
- Adds `BlockHeader.toRlp()` function for RLP encoding headers
- Works for both PoW (pre-merge) and PoS (post-merge) blocks
- Supports all optional post-fork fields (London, Shanghai, Cancun)

## Changes
- `src/primitives/BlockHeader/toRlp.js` - RLP encoding of block header in correct field order
- `src/primitives/BlockHeader/calculateHash.js` - keccak256(RLP(header)) 
- `src/primitives/BlockHeader/index.ts` - exports new functions
- `src/primitives/BlockHeader/BlockHeader.test.ts` - tests with real mainnet block 20,000,000

## Test plan
- [x] Added tests with real mainnet PoS block data (block 20,000,000)
- [x] Verified hash matches expected: 0xd24fd73f794058a3807db926d8898c6481e902b7edb91ce0d479d6760f276183
- [x] Tests for London, Shanghai, and pre-merge headers
- [x] All BlockHeader tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)