### PR TITLE
🐛 fix: Export Hex.concat() and all standalone functions from public API

### DIFF
--- a/src/primitives/Hex/index.d.ts
+++ b/src/primitives/Hex/index.d.ts
@@ -1,3 +1,30 @@
 export { Hex, fromBytes, toBytes } from "./Hex.js";
 export * from "./Hex.js";
 export type { HexType, Sized, Bytes } from "./HexType.js";
+
+// Standalone function exports (matching index.js)
+export { assertSize } from "./assertSize.js";
+export { clone } from "./clone.js";
+export { concat } from "./concat.js";
+export { equals } from "./equals.js";
+export { from } from "./from.js";
+export { fromBigInt } from "./fromBigInt.js";
+export { fromBoolean } from "./fromBoolean.js";
+export { fromNumber } from "./fromNumber.js";
+export { fromString } from "./fromString.js";
+export { isHex } from "./isHex.js";
+export { isSized } from "./isSized.js";
+export { pad } from "./pad.js";
+export { padRight } from "./padRight.js";
+export { random } from "./random.js";
+export { size } from "./size.js";
+export { slice } from "./slice.js";
+export { toBigInt } from "./toBigInt.js";
+export { toBoolean } from "./toBoolean.js";
+export { toNumber } from "./toNumber.js";
+// biome-ignore lint/suspicious/noShadowRestrictedNames: toString is intentional API name
+export { toString } from "./toString.js";
+export { trim } from "./trim.js";
+export { validate } from "./validate.js";
+export { xor } from "./xor.js";
+export { zero } from "./zero.js";


### PR DESCRIPTION
## Summary
- Fixes #156
- Added all 26 standalone function exports to `index.d.ts` that were missing
- Now TypeScript users can import `concat` and other functions directly

## Test plan
- [x] Verify exports match index.js
- [x] TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.ai/code)