### PR TITLE
🎉 feat: Add Rlp.decodeValue() for direct value extraction

### DIFF
--- a/src/primitives/Rlp/decodeValue.js
+++ b/src/primitives/Rlp/decodeValue.js
@@ -1,0 +1,38 @@
+import { decode } from "./decode.js";
+import { toRaw } from "./toRaw.js";
+
+/**
+ * Decodes RLP-encoded bytes and returns the value directly
+ *
+ * This is a convenience wrapper around decode() that returns just the decoded value
+ * without the metadata wrapper. For streaming/partial decoding with remainder access,
+ * use decode() instead.
+ *
+ * @see https://voltaire.tevm.sh/primitives/rlp for RLP documentation
+ * @since 0.1.42
+ * @param {Uint8Array} bytes - RLP-encoded data
+ * @returns {Uint8Array | any[]} Decoded value (Uint8Array for bytes, nested arrays for lists)
+ * @throws {import('./RlpError.js').RlpDecodingError} If decoding fails
+ * @example
+ * ```javascript
+ * import * as Rlp from './primitives/Rlp/index.js';
+ *
+ * // Decode bytes - returns Uint8Array directly
+ * const bytes = new Uint8Array([0x83, 1, 2, 3]);
+ * const value = Rlp.decodeValue(bytes);
+ * // => Uint8Array([1, 2, 3])
+ *
+ * // Decode list - returns nested arrays
+ * const list = new Uint8Array([0xc3, 0x01, 0x02, 0x03]);
+ * const items = Rlp.decodeValue(list);
+ * // => [Uint8Array([1]), Uint8Array([2]), Uint8Array([3])]
+ *
+ * // Compare with decode() which returns metadata:
+ * // Rlp.decode(bytes) => { data: { type: 'bytes', value: Uint8Array([1,2,3]) }, remainder: Uint8Array([]) }
+ * // Rlp.decodeValue(bytes) => Uint8Array([1, 2, 3])
+ * ```
+ */
+export function decodeValue(bytes) {
+	const decoded = decode(bytes);
+	return toRaw(decoded.data);
+}

--- a/src/primitives/Rlp/decodeValue.test.ts
+++ b/src/primitives/Rlp/decodeValue.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for Rlp.decodeValue() - convenience function for direct value decoding
+ *
+ * @see https://github.com/williamcory/voltaire/issues/152
+ */
+
+import { describe, expect, it } from "vitest";
+import { decodeValue } from "./decodeValue.js";
+import { encode } from "./encode.js";
+import { RlpDecodingError } from "./RlpError.js";
+
+describe("Rlp.decodeValue", () => {
+	describe("returns value directly (not wrapped object)", () => {
+		it("decodes single byte to Uint8Array", () => {
+			const input = new Uint8Array([0x42]);
+			const result = decodeValue(input);
+			expect(result).toBeInstanceOf(Uint8Array);
+			expect(result).toEqual(new Uint8Array([0x42]));
+		});
+
+		it("decodes short string to Uint8Array", () => {
+			const input = new Uint8Array([0x83, 1, 2, 3]);
+			const result = decodeValue(input);
+			expect(result).toBeInstanceOf(Uint8Array);
+			expect(result).toEqual(new Uint8Array([1, 2, 3]));
+		});
+
+		it("decodes empty bytes to empty Uint8Array", () => {
+			const input = new Uint8Array([0x80]);
+			const result = decodeValue(input);
+			expect(result).toBeInstanceOf(Uint8Array);
+			expect(result).toEqual(new Uint8Array([]));
+		});
+
+		it("decodes list to array of Uint8Arrays", () => {
+			const input = new Uint8Array([0xc2, 0x01, 0x02]);
+			const result = decodeValue(input);
+			expect(Array.isArray(result)).toBe(true);
+			expect(result).toEqual([
+				new Uint8Array([0x01]),
+				new Uint8Array([0x02]),
+			]);
+		});
+
+		it("decodes empty list to empty array", () => {
+			const input = new Uint8Array([0xc0]);
+			const result = decodeValue(input);
+			expect(Array.isArray(result)).toBe(true);
+			expect(result).toEqual([]);
+		});
+
+		it("decodes nested list to nested arrays", () => {
+			const input = new Uint8Array([0xc3, 0x01, 0xc1, 0x02]);
+			const result = decodeValue(input);
+			expect(result).toEqual([
+				new Uint8Array([0x01]),
+				[new Uint8Array([0x02])],
+			]);
+		});
+	});
+
+	describe("round-trip with encode", () => {
+		it("round-trips bytes", () => {
+			const original = new Uint8Array([1, 2, 3, 4, 5]);
+			const encoded = encode(original);
+			const decoded = decodeValue(encoded);
+			expect(decoded).toEqual(original);
+		});
+
+		it("round-trips list", () => {
+			const original = [
+				new Uint8Array([0x01]),
+				new Uint8Array([0x02]),
+				new Uint8Array([0x03]),
+			];
+			const encoded = encode(original);
+			const decoded = decodeValue(encoded);
+			expect(decoded).toEqual(original);
+		});
+
+		it("round-trips nested structure", () => {
+			const original = [
+				new Uint8Array([0x01]),
+				[new Uint8Array([0x02]), new Uint8Array([0x03])],
+			];
+			const encoded = encode(original);
+			const decoded = decodeValue(encoded);
+			expect(decoded).toEqual(original);
+		});
+
+		it("round-trips long string (56+ bytes)", () => {
+			const original = new Uint8Array(100).fill(0xff);
+			const encoded = encode(original);
+			const decoded = decodeValue(encoded);
+			expect(decoded).toEqual(original);
+		});
+	});
+
+	describe("error handling", () => {
+		it("throws RlpDecodingError on empty input", () => {
+			expect(() => decodeValue(new Uint8Array([]))).toThrow(RlpDecodingError);
+		});
+
+		it("throws RlpDecodingError on truncated input", () => {
+			// Claims 3 bytes but only has 2
+			const input = new Uint8Array([0x83, 1, 2]);
+			expect(() => decodeValue(input)).toThrow(RlpDecodingError);
+		});
+
+		it("throws on unexpected remainder (non-stream mode)", () => {
+			// Two separate values - second is remainder
+			const input = new Uint8Array([0x01, 0x02]);
+			expect(() => decodeValue(input)).toThrow(RlpDecodingError);
+		});
+	});
+
+	describe("comparison with decode() behavior", () => {
+		it("decodeValue returns raw value, decode returns wrapped object", async () => {
+			const { decode } = await import("./decode.js");
+			const input = new Uint8Array([0x83, 1, 2, 3]);
+
+			// decode() returns { data: { type, value }, remainder }
+			const decodeResult = decode(input);
+			expect(decodeResult).toHaveProperty("data");
+			expect(decodeResult).toHaveProperty("remainder");
+			expect(decodeResult.data).toHaveProperty("type");
+			expect(decodeResult.data).toHaveProperty("value");
+
+			// decodeValue() returns the value directly
+			const decodeValueResult = decodeValue(input);
+			expect(decodeValueResult).toBeInstanceOf(Uint8Array);
+			expect(decodeValueResult).toEqual(new Uint8Array([1, 2, 3]));
+		});
+	});
+});

--- a/src/primitives/Rlp/index.ts
+++ b/src/primitives/Rlp/index.ts
@@ -40,6 +40,7 @@ Rlp.encodeVariadic = BrandedRlpNs.encodeVariadic;
 Rlp.decode = BrandedRlpNs.decode;
 Rlp.decodeArray = BrandedRlpNs.decodeArray;
 Rlp.decodeObject = BrandedRlpNs.decodeObject;
+Rlp.decodeValue = BrandedRlpNs.decodeValue;
 Rlp.getEncodedLength = BrandedRlpNs.getEncodedLength;
 Rlp.flatten = BrandedRlpNs.flatten;
 Rlp.equals = BrandedRlpNs.equals;

--- a/src/primitives/Rlp/internal-index.ts
+++ b/src/primitives/Rlp/internal-index.ts
@@ -7,6 +7,7 @@ export * from "./RlpType.js";
 import { decode } from "./decode.js";
 import { decodeArray } from "./decodeArray.js";
 import { decodeBatch } from "./decodeBatch.js";
+import { decodeValue } from "./decodeValue.js";
 import { decodeObject } from "./decodeObject.js";
 import { encode } from "./encode.js";
 import { encodeArray } from "./encodeArray.js";
@@ -46,6 +47,7 @@ export {
 	decode,
 	decodeArray,
 	decodeObject,
+	decodeValue,
 	getEncodedLength,
 	flatten,
 	equals,
@@ -76,6 +78,7 @@ export const BrandedRlp = {
 	decode,
 	decodeArray,
 	decodeObject,
+	decodeValue,
 	getEncodedLength,
 	flatten,
 	equals,


### PR DESCRIPTION
## Summary
- Fixes #152
- Added `Rlp.decodeValue()` convenience function that returns decoded value directly
- Original `decode()` behavior preserved for streaming support

## Test plan
- [x] 14 tests for decodeValue covering bytes, lists, nested structures
- [x] Verify original decode() still works

🤖 Generated with [Claude Code](https://claude.ai/code)