### PR TITLE
🐛 fix: Export ZERO_ADDRESS constant from Address module

### DIFF
--- a/src/primitives/Address/constants.js
+++ b/src/primitives/Address/constants.js
@@ -18,3 +18,10 @@ export const HEX_SIZE = 42;
  */
 export const NATIVE_ASSET_ADDRESS =
 	"0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+/**
+ * Zero address constant (0x0000...0000)
+ * Commonly used for null/empty address checks and burn operations
+ * @type {string}
+ */
+export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";

--- a/src/primitives/Address/constants.test.ts
+++ b/src/primitives/Address/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { HEX_SIZE, SIZE } from "./constants.js";
+import { HEX_SIZE, SIZE, ZERO_ADDRESS } from "./constants.js";
 
 describe("constants", () => {
 	describe("SIZE", () => {
@@ -24,6 +24,24 @@ describe("constants", () => {
 
 		it("equals SIZE * 2 + 2 for 0x prefix", () => {
 			expect(HEX_SIZE).toBe(SIZE * 2 + 2);
+		});
+	});
+
+	describe("ZERO_ADDRESS", () => {
+		it("is a valid hex string of 42 characters", () => {
+			expect(ZERO_ADDRESS.length).toBe(HEX_SIZE);
+		});
+
+		it("starts with 0x prefix", () => {
+			expect(ZERO_ADDRESS.startsWith("0x")).toBe(true);
+		});
+
+		it("contains only zeros after prefix", () => {
+			expect(ZERO_ADDRESS).toBe("0x0000000000000000000000000000000000000000");
+		});
+
+		it("is lowercase", () => {
+			expect(ZERO_ADDRESS).toBe(ZERO_ADDRESS.toLowerCase());
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Fixes #151
- Added ZERO_ADDRESS constant (0x0000...0000) to Address module
- Added test coverage

## Test plan
- [x] ZERO_ADDRESS is 20 bytes
- [x] All bytes are zero
- [x] Valid Address type

🤖 Generated with [Claude Code](https://claude.ai/code)