### PR TITLE
📚 docs: Clarify Address constructor patterns

### DIFF
--- a/docs/examples/addresses/address-from-private-key.mdx
+++ b/docs/examples/addresses/address-from-private-key.mdx
@@ -6,7 +6,7 @@ description: "Generate an Ethereum address from a private key using public key d
 Generate an Ethereum address from a private key using public key derivation
 
 ```typescript
-import { Address } from '@tevm/voltaire/Address';
+import * as Address from '@tevm/voltaire/Address';
 import * as Hex from '@tevm/voltaire/Hex';
 
 // Example private key (32 bytes)
@@ -16,6 +16,8 @@ const privateKey = Hex.toBytes(
 
 // Derive address from private key
 const address = Address.fromPrivateKey(privateKey);
+
+// Get checksummed representation (static method)
 const checksummed = Address.toChecksummed(address);
 
 // Try another private key

--- a/docs/primitives/address.mdx
+++ b/docs/primitives/address.mdx
@@ -104,8 +104,7 @@ Address.isValidChecksum("0x742d35cc6634c0532925a3b844bc9e7595f51e3e"); // false
 
 | Method | Description |
 |--------|-------------|
-| `Address(value)` | Create from hex string, bytes, or number |
-| `Address.from(value)` | Alias for `Address()` |
+| `Address(value)` | **Primary constructor** - create from hex string, bytes, or number |
 | `Address.fromHex(hex)` | Create from hex string |
 | `Address.fromBytes(bytes)` | Create from Uint8Array |
 | `Address.fromNumber(n)` | Create from number or bigint |


### PR DESCRIPTION
## Summary
- Fixes #149
- Removed confusing `Address.from()` alias from API reference table
- Clarified `Address()` as the primary constructor
- Updated import pattern in example to use namespace style

## Test plan
- [x] Docs build correctly
- [x] Examples show consistent patterns

🤖 Generated with [Claude Code](https://claude.ai/code)