### PR TITLE
🎉 feat: Add Block.fromRpc() for JSON-RPC response parsing

### DIFF
--- a/src/primitives/Block/fromRpc.js
+++ b/src/primitives/Block/fromRpc.js
@@ -1,0 +1,57 @@
+import { fromRpc as blockBodyFromRpc } from "../BlockBody/fromRpc.js";
+import { fromRpc as blockHeaderFromRpc } from "../BlockHeader/fromRpc.js";
+import { from } from "./from.js";
+
+/**
+ * @typedef {import('../BlockHeader/fromRpc.js').RpcBlockHeader} RpcBlockHeader
+ * @typedef {import('../BlockBody/fromRpc.js').RpcBlockBody} RpcBlockBody
+ */
+
+/**
+ * @typedef {RpcBlockHeader & RpcBlockBody & {
+ *   hash: string,
+ *   size: string,
+ *   totalDifficulty?: string
+ * }} RpcBlock
+ */
+
+/**
+ * Convert RPC block format to Block
+ *
+ * Handles conversion of all hex-encoded strings from JSON-RPC to native types.
+ * Includes header fields, body (transactions, withdrawals), and block metadata.
+ *
+ * @see https://voltaire.tevm.sh/primitives/block for Block documentation
+ * @since 0.1.42
+ * @param {RpcBlock} rpc - RPC block object (from eth_getBlockByNumber/Hash)
+ * @returns {import('./BlockType.js').BlockType} Block
+ * @throws {import('../errors/index.js').InvalidFormatError} If hex format is invalid
+ * @throws {import('../errors/index.js').InvalidLengthError} If field length is incorrect
+ * @throws {import('../errors/index.js').InvalidTransactionTypeError} If transaction type is unknown
+ * @example
+ * ```javascript
+ * import * as Block from './primitives/Block/index.js';
+ *
+ * // From JSON-RPC response (eth_getBlockByNumber with full transactions)
+ * const rpcBlock = await provider.send('eth_getBlockByNumber', ['latest', true]);
+ * const block = Block.fromRpc(rpcBlock);
+ *
+ * console.log(block.header.number); // bigint
+ * console.log(block.header.gasUsed); // bigint
+ * console.log(block.body.transactions.length);
+ * ```
+ */
+export function fromRpc(rpc) {
+	const header = blockHeaderFromRpc(rpc);
+	const body = blockBodyFromRpc(rpc);
+
+	return from({
+		header,
+		body,
+		hash: rpc.hash,
+		size: BigInt(rpc.size),
+		...(rpc.totalDifficulty !== undefined && {
+			totalDifficulty: BigInt(rpc.totalDifficulty),
+		}),
+	});
+}

--- a/src/primitives/Block/index.ts
+++ b/src/primitives/Block/index.ts
@@ -3,9 +3,24 @@ export type { BlockType } from "./BlockType.js";
 
 // Import internal functions
 import { from as _from } from "./from.js";
+import { fromRpc as _fromRpc } from "./fromRpc.js";
 
 // Export internal functions (tree-shakeable)
-export { _from };
+export { _from, _fromRpc };
+
+// Re-export RPC types from dependencies
+export type { RpcBlockHeader } from "../BlockHeader/index.js";
+export type { RpcBlockBody, RpcWithdrawal } from "../BlockBody/index.js";
+
+/**
+ * RPC block format (full JSON-RPC eth_getBlockByNumber/Hash response)
+ */
+export type RpcBlock = import("../BlockHeader/index.js").RpcBlockHeader &
+	import("../BlockBody/index.js").RpcBlockBody & {
+		hash: string;
+		size: string;
+		totalDifficulty?: string;
+	};
 
 // Export public functions
 export function from(params: {
@@ -18,7 +33,18 @@ export function from(params: {
 	return _from(params);
 }
 
+/**
+ * Convert RPC block format to Block
+ *
+ * Use this to parse JSON-RPC responses from eth_getBlockByNumber or eth_getBlockByHash.
+ * Handles conversion of all hex-encoded strings to native types.
+ */
+export function fromRpc(rpc: RpcBlock) {
+	return _fromRpc(rpc);
+}
+
 // Namespace export
 export const Block = {
 	from,
+	fromRpc,
 };

--- a/src/primitives/Block/rpc.test.ts
+++ b/src/primitives/Block/rpc.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import * as Block from "./index.js";
+import * as BlockBody from "../BlockBody/index.js";
+import * as BlockHeader from "../BlockHeader/index.js";
+import * as Withdrawal from "../Withdrawal/index.js";
+
+describe("Block.fromRpc", () => {
+	// Sample RPC block response (simplified, based on real mainnet data)
+	const minimalRpcBlock = {
+		// Header fields
+		parentHash:
+			"0x1234567890123456789012345678901234567890123456789012345678901234",
+		sha3Uncles:
+			"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		miner: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+		stateRoot:
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		transactionsRoot:
+			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		receiptsRoot:
+			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		logsBloom: `0x${"00".repeat(256)}`,
+		difficulty: "0x0",
+		number: "0x12d687",
+		gasLimit: "0x1c9c380",
+		gasUsed: "0x5208",
+		timestamp: "0x5f5e100",
+		extraData: "0x",
+		mixHash:
+			"0x0000000000000000000000000000000000000000000000000000000000000000",
+		nonce: "0x0000000000000000",
+		// Block metadata
+		hash: "0xabababababababababababababababababababababababababababababababab",
+		size: "0x400",
+		// Body
+		transactions: [],
+		uncles: [],
+	};
+
+	it("parses minimal post-merge block", () => {
+		const block = Block.fromRpc(minimalRpcBlock);
+
+		expect(block.header.number).toBe(0x12d687n);
+		expect(block.header.gasLimit).toBe(0x1c9c380n);
+		expect(block.header.gasUsed).toBe(0x5208n);
+		expect(block.header.timestamp).toBe(0x5f5e100n);
+		expect(block.header.difficulty).toBe(0n);
+		expect(block.size).toBe(0x400n);
+		expect(block.body.transactions).toHaveLength(0);
+	});
+
+	it("parses block with EIP-1559 fields", () => {
+		const rpcBlock = {
+			...minimalRpcBlock,
+			baseFeePerGas: "0x3b9aca00",
+		};
+
+		const block = Block.fromRpc(rpcBlock);
+
+		expect(block.header.baseFeePerGas).toBe(0x3b9aca00n);
+	});
+
+	it("parses block with EIP-4844 fields", () => {
+		const rpcBlock = {
+			...minimalRpcBlock,
+			baseFeePerGas: "0x3b9aca00",
+			blobGasUsed: "0x20000",
+			excessBlobGas: "0x0",
+			parentBeaconBlockRoot:
+				"0xdef0def0def0def0def0def0def0def0def0def0def0def0def0def0def0def0",
+		};
+
+		const block = Block.fromRpc(rpcBlock);
+
+		expect(block.header.blobGasUsed).toBe(0x20000n);
+		expect(block.header.excessBlobGas).toBe(0n);
+		expect(block.header.parentBeaconBlockRoot).toBeDefined();
+	});
+
+	it("parses block with withdrawals", () => {
+		const rpcBlock = {
+			...minimalRpcBlock,
+			baseFeePerGas: "0x3b9aca00",
+			withdrawalsRoot:
+				"0xdef0def0def0def0def0def0def0def0def0def0def0def0def0def0def0def0",
+			withdrawals: [
+				{
+					index: "0x1",
+					validatorIndex: "0x2",
+					address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+					amount: "0x773594000",
+				},
+			],
+		};
+
+		const block = Block.fromRpc(rpcBlock);
+
+		expect(block.header.withdrawalsRoot).toBeDefined();
+		expect(block.body.withdrawals).toHaveLength(1);
+		// WithdrawalIndexType is bigint
+		expect(block.body.withdrawals?.[0].index).toBe(1n);
+		// ValidatorIndexType is number (safe integer constraint)
+		expect(block.body.withdrawals?.[0].validatorIndex).toBe(2);
+		// GweiType is string
+		expect(block.body.withdrawals?.[0].amount).toBe("32000000000");
+	});
+
+	it("parses block with transactions", () => {
+		const rpcBlock = {
+			...minimalRpcBlock,
+			baseFeePerGas: "0x3b9aca00",
+			transactions: [
+				{
+					type: "0x2",
+					chainId: "0x1",
+					nonce: "0x0",
+					maxPriorityFeePerGas: "0x3b9aca00",
+					maxFeePerGas: "0x4a817c800",
+					gas: "0x5208",
+					to: `0x${"12".repeat(20)}`,
+					value: "0xde0b6b3a7640000",
+					input: "0x",
+					accessList: [],
+					yParity: "0x0",
+					r: `0x${"11".repeat(32)}`,
+					s: `0x${"22".repeat(32)}`,
+				},
+			],
+		};
+
+		const block = Block.fromRpc(rpcBlock);
+
+		expect(block.body.transactions).toHaveLength(1);
+		expect(block.body.transactions[0].type).toBe(2);
+		expect(block.body.transactions[0].nonce).toBe(0n);
+		expect(block.body.transactions[0].value).toBe(0xde0b6b3a7640000n);
+	});
+
+	it("parses block with totalDifficulty (pre-merge)", () => {
+		const rpcBlock = {
+			...minimalRpcBlock,
+			difficulty: "0x2000000000000",
+			totalDifficulty: "0x36e1945c08bf2ab5",
+		};
+
+		const block = Block.fromRpc(rpcBlock);
+
+		expect(block.header.difficulty).toBe(0x2000000000000n);
+		expect(block.totalDifficulty).toBe(0x36e1945c08bf2ab5n);
+	});
+});
+
+describe("BlockHeader.fromRpc", () => {
+	const minimalRpcHeader = {
+		parentHash:
+			"0x1234567890123456789012345678901234567890123456789012345678901234",
+		sha3Uncles:
+			"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		miner: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+		stateRoot:
+			"0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		transactionsRoot:
+			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		receiptsRoot:
+			"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+		logsBloom: `0x${"00".repeat(256)}`,
+		difficulty: "0x0",
+		number: "0x1",
+		gasLimit: "0x1c9c380",
+		gasUsed: "0x0",
+		timestamp: "0x5f5e100",
+		extraData: "0x",
+		mixHash:
+			"0x0000000000000000000000000000000000000000000000000000000000000000",
+		nonce: "0x0000000000000000",
+	};
+
+	it("parses minimal header", () => {
+		const header = BlockHeader.fromRpc(minimalRpcHeader);
+
+		expect(header.number).toBe(1n);
+		expect(header.gasLimit).toBe(0x1c9c380n);
+		expect(header.difficulty).toBe(0n);
+		expect(header.logsBloom).toHaveLength(256);
+		expect(header.nonce).toHaveLength(8);
+	});
+
+	it("maps RPC field names correctly", () => {
+		const header = BlockHeader.fromRpc(minimalRpcHeader);
+
+		// sha3Uncles -> ommersHash
+		expect(header.ommersHash).toBeDefined();
+		// miner -> beneficiary
+		expect(header.beneficiary).toBeDefined();
+	});
+
+	it("handles optional EIP-1559 baseFeePerGas", () => {
+		const header = BlockHeader.fromRpc({
+			...minimalRpcHeader,
+			baseFeePerGas: "0x3b9aca00",
+		});
+
+		expect(header.baseFeePerGas).toBe(1000000000n);
+	});
+
+	it("handles optional EIP-4844 fields", () => {
+		const header = BlockHeader.fromRpc({
+			...minimalRpcHeader,
+			baseFeePerGas: "0x3b9aca00",
+			blobGasUsed: "0x20000",
+			excessBlobGas: "0x40000",
+			parentBeaconBlockRoot:
+				"0xdef0def0def0def0def0def0def0def0def0def0def0def0def0def0def0def0",
+		});
+
+		expect(header.blobGasUsed).toBe(0x20000n);
+		expect(header.excessBlobGas).toBe(0x40000n);
+		expect(header.parentBeaconBlockRoot).toBeDefined();
+	});
+});
+
+describe("BlockBody.fromRpc", () => {
+	it("parses empty body", () => {
+		const body = BlockBody.fromRpc({
+			transactions: [],
+			uncles: [],
+		});
+
+		expect(body.transactions).toHaveLength(0);
+		expect(body.ommers).toHaveLength(0);
+		expect(body.withdrawals).toBeUndefined();
+	});
+
+	it("parses body with withdrawals", () => {
+		const body = BlockBody.fromRpc({
+			transactions: [],
+			uncles: [],
+			withdrawals: [
+				{
+					index: "0xa",
+					validatorIndex: "0x14",
+					address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+					amount: "0x773594000",
+				},
+			],
+		});
+
+		expect(body.withdrawals).toHaveLength(1);
+		// WithdrawalIndexType is bigint
+		expect(body.withdrawals?.[0].index).toBe(10n);
+		// ValidatorIndexType is number
+		expect(body.withdrawals?.[0].validatorIndex).toBe(20);
+	});
+
+	it("parses body with legacy transaction", () => {
+		const body = BlockBody.fromRpc({
+			transactions: [
+				{
+					type: "0x0",
+					nonce: "0x1",
+					gasPrice: "0x4a817c800",
+					gas: "0x5208",
+					to: `0x${"12".repeat(20)}`,
+					value: "0xde0b6b3a7640000",
+					data: "0xabcd",
+					v: "0x1b",
+					r: `0x${"11".repeat(32)}`,
+					s: `0x${"22".repeat(32)}`,
+				},
+			],
+			uncles: [],
+		});
+
+		expect(body.transactions).toHaveLength(1);
+		expect(body.transactions[0].type).toBe(0);
+		expect(body.transactions[0].gasLimit).toBe(21000n);
+	});
+});
+
+describe("Withdrawal.fromRpc", () => {
+	it("parses withdrawal", () => {
+		const withdrawal = Withdrawal.fromRpc({
+			index: "0x1",
+			validatorIndex: "0x1e240",
+			address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+			amount: "0x773594000",
+		});
+
+		// WithdrawalIndexType is bigint
+		expect(withdrawal.index).toBe(1n);
+		// ValidatorIndexType is number (safe integer constraint)
+		expect(withdrawal.validatorIndex).toBe(123456);
+		// GweiType is string
+		expect(withdrawal.amount).toBe("32000000000");
+	});
+
+	it("handles large index values", () => {
+		const withdrawal = Withdrawal.fromRpc({
+			index: "0xffffffffffffffff",
+			validatorIndex: "0x7fffffff", // Use safe integer (max signed 32-bit)
+			address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+			amount: "0xffffffffffffffff",
+		});
+
+		// WithdrawalIndexType is bigint - can handle large values
+		expect(withdrawal.index).toBe(0xffffffffffffffffn);
+		// ValidatorIndexType is number - must be safe integer
+		expect(withdrawal.validatorIndex).toBe(0x7fffffff);
+	});
+});

--- a/src/primitives/BlockBody/fromRpc.js
+++ b/src/primitives/BlockBody/fromRpc.js
@@ -1,0 +1,59 @@
+import { fromRpc as transactionFromRpc } from "../Transaction/fromRpc.js";
+import { fromRpc as withdrawalFromRpc } from "../Withdrawal/fromRpc.js";
+import { from } from "./from.js";
+
+/**
+ * @typedef {import('../Transaction/fromRpc.js').RpcTransaction} RpcTransaction
+ * @typedef {import('../Withdrawal/fromRpc.js').RpcWithdrawal} RpcWithdrawal
+ */
+
+/**
+ * @typedef {Object} RpcBlockBody
+ * @property {RpcTransaction[]} transactions - Array of RPC transactions
+ * @property {any[]} [uncles] - Array of uncle blocks (ommers)
+ * @property {RpcWithdrawal[]} [withdrawals] - Array of RPC withdrawals (post-Shanghai)
+ */
+
+/**
+ * Convert RPC block body format to BlockBody
+ *
+ * Handles conversion of transactions and withdrawals from JSON-RPC format.
+ * Note: Uncle (ommer) parsing is not yet implemented - they are passed through as-is.
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-body for BlockBody documentation
+ * @since 0.1.42
+ * @param {RpcBlockBody} rpc - RPC block body object
+ * @returns {import('./BlockBodyType.js').BlockBodyType} BlockBody
+ * @throws {import('../errors/index.js').InvalidTransactionTypeError} If transaction type is unknown
+ * @throws {import('../errors/index.js').InvalidLengthError} If field length is incorrect
+ * @example
+ * ```javascript
+ * import * as BlockBody from './primitives/BlockBody/index.js';
+ * const rpcBody = {
+ *   transactions: [
+ *     { type: "0x2", nonce: "0x1", ... }
+ *   ],
+ *   uncles: [],
+ *   withdrawals: [
+ *     { index: "0x1", validatorIndex: "0x2", address: "0x...", amount: "0x..." }
+ *   ]
+ * };
+ * const body = BlockBody.fromRpc(rpcBody);
+ * ```
+ */
+export function fromRpc(rpc) {
+	const transactions = rpc.transactions.map((tx) => transactionFromRpc(tx));
+
+	// Note: Uncles/ommers are passed through - full parsing not yet implemented
+	const ommers = rpc.uncles || [];
+
+	const withdrawals = rpc.withdrawals
+		? rpc.withdrawals.map((w) => withdrawalFromRpc(w))
+		: undefined;
+
+	return from({
+		transactions,
+		ommers,
+		...(withdrawals !== undefined && { withdrawals }),
+	});
+}

--- a/src/primitives/BlockBody/index.ts
+++ b/src/primitives/BlockBody/index.ts
@@ -3,14 +3,35 @@ export type { BlockBodyType } from "./BlockBodyType.js";
 
 // Import internal functions
 import { from as _from } from "./from.js";
+import { fromRpc as _fromRpc } from "./fromRpc.js";
 
 // Export internal functions (tree-shakeable)
-export { _from };
+export { _from, _fromRpc };
 
 // Type imports for function parameters
 type AnyTransaction = import("../Transaction/types.js").Any;
 type UncleType = import("../Uncle/UncleType.js").UncleType;
 type WithdrawalType = import("../Withdrawal/WithdrawalType.js").WithdrawalType;
+type RpcTransaction = import("../Transaction/fromRpc.js").RpcTransaction;
+
+/**
+ * RPC withdrawal format
+ */
+export type RpcWithdrawal = {
+	index: string;
+	validatorIndex: string;
+	address: string;
+	amount: string;
+};
+
+/**
+ * RPC block body format (subset of JSON-RPC block response)
+ */
+export type RpcBlockBody = {
+	transactions: RpcTransaction[];
+	uncles?: unknown[];
+	withdrawals?: RpcWithdrawal[];
+};
 
 // Export public functions
 export function from(params: {
@@ -21,7 +42,15 @@ export function from(params: {
 	return _from(params);
 }
 
+/**
+ * Convert RPC block body format to BlockBody
+ */
+export function fromRpc(rpc: RpcBlockBody) {
+	return _fromRpc(rpc);
+}
+
 // Namespace export
 export const BlockBody = {
 	from,
+	fromRpc,
 };

--- a/src/primitives/BlockHeader/fromRpc.js
+++ b/src/primitives/BlockHeader/fromRpc.js
@@ -1,0 +1,107 @@
+import { toBytes } from "../Hex/toBytes.js";
+import { from } from "./from.js";
+
+/**
+ * Convert hex string to bigint, handling undefined/null
+ * @param {string | undefined | null} hex
+ * @returns {bigint}
+ */
+function hexToBigInt(hex) {
+	if (!hex) return 0n;
+	return BigInt(hex);
+}
+
+/**
+ * @typedef {Object} RpcBlockHeader
+ * @property {string} parentHash - Parent block hash (32 bytes hex)
+ * @property {string} sha3Uncles - Ommers hash (32 bytes hex)
+ * @property {string} miner - Beneficiary address (20 bytes hex)
+ * @property {string} stateRoot - State trie root (32 bytes hex)
+ * @property {string} transactionsRoot - Transactions trie root (32 bytes hex)
+ * @property {string} receiptsRoot - Receipts trie root (32 bytes hex)
+ * @property {string} logsBloom - Logs bloom filter (256 bytes hex)
+ * @property {string} difficulty - PoW difficulty (hex)
+ * @property {string} number - Block number (hex)
+ * @property {string} gasLimit - Gas limit (hex)
+ * @property {string} gasUsed - Gas used (hex)
+ * @property {string} timestamp - Unix timestamp (hex)
+ * @property {string} extraData - Extra data (hex)
+ * @property {string} mixHash - PoW mix hash (32 bytes hex)
+ * @property {string} nonce - PoW nonce (8 bytes hex)
+ * @property {string} [baseFeePerGas] - Base fee per gas (hex, EIP-1559)
+ * @property {string} [withdrawalsRoot] - Withdrawals root (32 bytes hex, post-Shanghai)
+ * @property {string} [blobGasUsed] - Blob gas used (hex, EIP-4844)
+ * @property {string} [excessBlobGas] - Excess blob gas (hex, EIP-4844)
+ * @property {string} [parentBeaconBlockRoot] - Parent beacon block root (32 bytes hex, EIP-4788)
+ */
+
+/**
+ * Convert RPC block header format to BlockHeader
+ *
+ * Handles conversion of hex-encoded strings from JSON-RPC to native types.
+ * Field names follow Ethereum JSON-RPC conventions (miner, sha3Uncles, etc).
+ *
+ * @see https://voltaire.tevm.sh/primitives/block-header for BlockHeader documentation
+ * @since 0.1.42
+ * @param {RpcBlockHeader} rpc - RPC block header object
+ * @returns {import('./BlockHeaderType.js').BlockHeaderType} BlockHeader
+ * @throws {import('../errors/index.js').InvalidFormatError} If hex format is invalid
+ * @throws {import('../errors/index.js').InvalidLengthError} If field length is incorrect
+ * @example
+ * ```javascript
+ * import * as BlockHeader from './primitives/BlockHeader/index.js';
+ * const rpcHeader = {
+ *   parentHash: "0x...",
+ *   sha3Uncles: "0x...",
+ *   miner: "0x...",
+ *   stateRoot: "0x...",
+ *   transactionsRoot: "0x...",
+ *   receiptsRoot: "0x...",
+ *   logsBloom: "0x...",
+ *   difficulty: "0x0",
+ *   number: "0x1",
+ *   gasLimit: "0x1c9c380",
+ *   gasUsed: "0x5208",
+ *   timestamp: "0x5f5e100",
+ *   extraData: "0x",
+ *   mixHash: "0x...",
+ *   nonce: "0x0000000000000000",
+ *   baseFeePerGas: "0x3b9aca00"
+ * };
+ * const header = BlockHeader.fromRpc(rpcHeader);
+ * ```
+ */
+export function fromRpc(rpc) {
+	return from({
+		parentHash: rpc.parentHash,
+		ommersHash: rpc.sha3Uncles,
+		beneficiary: rpc.miner,
+		stateRoot: rpc.stateRoot,
+		transactionsRoot: rpc.transactionsRoot,
+		receiptsRoot: rpc.receiptsRoot,
+		logsBloom: toBytes(rpc.logsBloom),
+		difficulty: hexToBigInt(rpc.difficulty),
+		number: hexToBigInt(rpc.number),
+		gasLimit: hexToBigInt(rpc.gasLimit),
+		gasUsed: hexToBigInt(rpc.gasUsed),
+		timestamp: hexToBigInt(rpc.timestamp),
+		extraData: toBytes(rpc.extraData),
+		mixHash: rpc.mixHash,
+		nonce: toBytes(rpc.nonce),
+		...(rpc.baseFeePerGas !== undefined && {
+			baseFeePerGas: hexToBigInt(rpc.baseFeePerGas),
+		}),
+		...(rpc.withdrawalsRoot !== undefined && {
+			withdrawalsRoot: rpc.withdrawalsRoot,
+		}),
+		...(rpc.blobGasUsed !== undefined && {
+			blobGasUsed: hexToBigInt(rpc.blobGasUsed),
+		}),
+		...(rpc.excessBlobGas !== undefined && {
+			excessBlobGas: hexToBigInt(rpc.excessBlobGas),
+		}),
+		...(rpc.parentBeaconBlockRoot !== undefined && {
+			parentBeaconBlockRoot: rpc.parentBeaconBlockRoot,
+		}),
+	});
+}

--- a/src/primitives/BlockHeader/index.ts
+++ b/src/primitives/BlockHeader/index.ts
@@ -3,9 +3,10 @@ export type { BlockHeaderType } from "./BlockHeaderType.js";
 
 // Import internal functions
 import { from as _from } from "./from.js";
+import { fromRpc as _fromRpc } from "./fromRpc.js";
 
 // Export internal functions (tree-shakeable)
-export { _from };
+export { _from, _fromRpc };
 
 // Export public functions
 export function from(params: {
@@ -33,7 +34,41 @@ export function from(params: {
 	return _from(params as Parameters<typeof _from>[0]);
 }
 
+/**
+ * RPC block header format (JSON-RPC response)
+ */
+export type RpcBlockHeader = {
+	parentHash: string;
+	sha3Uncles: string;
+	miner: string;
+	stateRoot: string;
+	transactionsRoot: string;
+	receiptsRoot: string;
+	logsBloom: string;
+	difficulty: string;
+	number: string;
+	gasLimit: string;
+	gasUsed: string;
+	timestamp: string;
+	extraData: string;
+	mixHash: string;
+	nonce: string;
+	baseFeePerGas?: string;
+	withdrawalsRoot?: string;
+	blobGasUsed?: string;
+	excessBlobGas?: string;
+	parentBeaconBlockRoot?: string;
+};
+
+/**
+ * Convert RPC block header format to BlockHeader
+ */
+export function fromRpc(rpc: RpcBlockHeader) {
+	return _fromRpc(rpc);
+}
+
 // Namespace export
 export const BlockHeader = {
 	from,
+	fromRpc,
 };

--- a/src/primitives/Withdrawal/fromRpc.js
+++ b/src/primitives/Withdrawal/fromRpc.js
@@ -1,0 +1,38 @@
+import { from } from "./from.js";
+
+/**
+ * @typedef {Object} RpcWithdrawal
+ * @property {string} index - Withdrawal index (hex)
+ * @property {string} validatorIndex - Validator index (hex)
+ * @property {string} address - Recipient address (hex)
+ * @property {string} amount - Amount in Gwei (hex)
+ */
+
+/**
+ * Convert RPC withdrawal format to Withdrawal
+ *
+ * @see https://voltaire.tevm.sh/primitives/withdrawal for Withdrawal documentation
+ * @since 0.1.42
+ * @param {RpcWithdrawal} rpc - RPC withdrawal object
+ * @returns {import('./WithdrawalType.js').WithdrawalType} Withdrawal
+ * @throws {never}
+ * @example
+ * ```javascript
+ * import * as Withdrawal from './primitives/Withdrawal/index.js';
+ * const rpcWithdrawal = {
+ *   index: "0x1",
+ *   validatorIndex: "0x2",
+ *   address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+ *   amount: "0x773594000" // 32 ETH in Gwei
+ * };
+ * const withdrawal = Withdrawal.fromRpc(rpcWithdrawal);
+ * ```
+ */
+export function fromRpc(rpc) {
+	return from({
+		index: BigInt(rpc.index),
+		validatorIndex: BigInt(rpc.validatorIndex),
+		address: rpc.address,
+		amount: BigInt(rpc.amount),
+	});
+}

--- a/src/primitives/Withdrawal/index.ts
+++ b/src/primitives/Withdrawal/index.ts
@@ -2,10 +2,12 @@ export type { WithdrawalType } from "./WithdrawalType.js";
 
 import { equals } from "./equals.js";
 import { from } from "./from.js";
+import { fromRpc } from "./fromRpc.js";
 
-export { from, equals };
+export { from, equals, fromRpc };
 
 export const Withdrawal = {
 	from,
 	equals,
+	fromRpc,
 };


### PR DESCRIPTION
## Summary
- Fixes #145
- Added `fromRpc` functions for Block, BlockHeader, BlockBody, Withdrawal
- Converts hex strings to native types (bigint, Uint8Array)
- Maps RPC field names to internal names
- Handles optional post-merge fields

## Test plan
- [x] 15 test cases covering all field types
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)