### PR TITLE
🐛 fix: Make Signature.toCompact() EIP-2098 compliant

### DIFF
--- a/src/crypto/Secp256k1/Signature/Signature.test.ts
+++ b/src/crypto/Secp256k1/Signature/Signature.test.ts
@@ -140,7 +140,7 @@ describe("Secp256k1.Signature methods", () => {
 		});
 	});
 
-	describe("toCompact", () => {
+	describe("toCompact (EIP-2098)", () => {
 		it("should convert signature to 64-byte compact format", () => {
 			const signature = {
 				r: new Uint8Array(32).fill(1),
@@ -154,10 +154,10 @@ describe("Secp256k1.Signature methods", () => {
 			expect(compact).toBeInstanceOf(Uint8Array);
 		});
 
-		it("should encode r || s without v", () => {
+		it("should encode r || s with yParity in bit 255 (EIP-2098)", () => {
 			const r = new Uint8Array(32).fill(0xaa);
-			const s = new Uint8Array(32).fill(0xbb);
-			const v = 28;
+			const s = new Uint8Array(32).fill(0x3b); // Use 0x3b to avoid high bit
+			const v = 28; // yParity = 1
 
 			const signature = { r, s, v };
 			const compact = toCompact(signature);
@@ -166,28 +166,32 @@ describe("Secp256k1.Signature methods", () => {
 			for (let i = 0; i < 32; i++) {
 				expect(compact[i]).toBe(0xaa);
 			}
-			// Check s
-			for (let i = 32; i < 64; i++) {
-				expect(compact[i]).toBe(0xbb);
+			// Check s - first byte has bit 255 set for yParity=1
+			expect(compact[32]).toBe(0x3b | 0x80); // 0xbb
+			for (let i = 33; i < 64; i++) {
+				expect(compact[i]).toBe(0x3b);
 			}
-			// No v in compact format
-			expect(compact.length).toBe(64);
 		});
 
-		it("should ignore v parameter", () => {
+		it("should encode different yParity in bit 255 (EIP-2098)", () => {
 			const base = {
 				r: new Uint8Array(32).fill(1),
-				s: new Uint8Array(32).fill(2),
+				s: new Uint8Array(32).fill(0x02), // Use low value for s
 			};
 
-			// v shouldn't affect compact output
+			// v=27 (yParity=0) -> bit 255 clear
 			const compact27 = toCompact({ ...base, v: 27 });
-			const compact28 = toCompact({ ...base, v: 28 });
+			expect(compact27[32] & 0x80).toBe(0x00);
 
-			expect(compact27).toEqual(compact28);
+			// v=28 (yParity=1) -> bit 255 set
+			const compact28 = toCompact({ ...base, v: 28 });
+			expect(compact28[32] & 0x80).toBe(0x80);
+
+			// Compacts should differ in bit 255
+			expect(compact27).not.toEqual(compact28);
 		});
 
-		it("should convert real signature to compact", () => {
+		it("should convert real signature to compact (EIP-2098)", () => {
 			const privateKeyBytes = new Uint8Array(32);
 			privateKeyBytes[31] = 1;
 			const privateKey = PrivateKey.fromBytes(privateKeyBytes);
@@ -198,19 +202,31 @@ describe("Secp256k1.Signature methods", () => {
 			const compact = toCompact(signature);
 
 			expect(compact.length).toBe(64);
-			// Compare using Array.from since HashType is Uint8Array
+			// r should match
 			expect(Array.from(compact.slice(0, 32))).toEqual(Array.from(signature.r));
-			expect(Array.from(compact.slice(32, 64))).toEqual(
-				Array.from(signature.s),
-			);
+			// s[0] may have bit 255 set based on yParity
+			const yParity =
+				signature.v <= 1
+					? signature.v
+					: signature.v === 27 || signature.v === 28
+						? signature.v - 27
+						: (signature.v - 35) % 2;
+			if (yParity === 1) {
+				expect(compact[32] & 0x80).toBe(0x80);
+				expect(compact[32] & 0x7f).toBe(signature.s[0] & 0x7f);
+			} else {
+				expect(Array.from(compact.slice(32, 64))).toEqual(
+					Array.from(signature.s),
+				);
+			}
 		});
 	});
 
-	describe("fromCompact", () => {
-		it("should parse 64-byte compact signature", () => {
+	describe("fromCompact (EIP-2098)", () => {
+		it("should parse 64-byte compact signature and clear bit 255", () => {
 			const compact = new Uint8Array(64);
 			for (let i = 0; i < 32; i++) compact[i] = 0xaa; // r
-			for (let i = 32; i < 64; i++) compact[i] = 0xbb; // s
+			for (let i = 32; i < 64; i++) compact[i] = 0x3b; // s (low value without high bit)
 			const v = 27;
 
 			const signature = fromCompact(compact, v);
@@ -221,7 +237,7 @@ describe("Secp256k1.Signature methods", () => {
 
 			for (let i = 0; i < 32; i++) {
 				expect(signature.r[i]).toBe(0xaa);
-				expect(signature.s[i]).toBe(0xbb);
+				expect(signature.s[i]).toBe(0x3b);
 			}
 		});
 
@@ -275,12 +291,12 @@ describe("Secp256k1.Signature methods", () => {
 		});
 	});
 
-	describe("cross-format conversion", () => {
+	describe("cross-format conversion (EIP-2098)", () => {
 		it("should convert between full and compact formats", () => {
 			const signature = {
 				r: new Uint8Array(32).fill(0x42),
-				s: new Uint8Array(32).fill(0x99),
-				v: 28,
+				s: new Uint8Array(32).fill(0x19), // Use low value for s
+				v: 28, // yParity = 1
 			};
 
 			// Full -> Compact -> Full
@@ -330,7 +346,7 @@ describe("Secp256k1.Signature methods", () => {
 		});
 	});
 
-	describe("edge cases", () => {
+	describe("edge cases (EIP-2098)", () => {
 		it("should handle all-zero r and s", () => {
 			const signature = {
 				r: new Uint8Array(32),
@@ -353,11 +369,12 @@ describe("Secp256k1.Signature methods", () => {
 			expect(Array.from(parsedCompact.s)).toEqual(Array.from(signature.s));
 		});
 
-		it("should handle all-ones r and s", () => {
+		it("should handle s with high bit and yParity encoding", () => {
+			// Use s value that doesn't have high bit set to avoid confusion
 			const signature = {
 				r: new Uint8Array(32).fill(0xff),
-				s: new Uint8Array(32).fill(0xff),
-				v: 27,
+				s: new Uint8Array(32).fill(0x7f), // 0x7f doesn't have bit 255 set
+				v: 27, // yParity = 0
 			};
 
 			const fullBytes = toBytes(signature);
@@ -369,22 +386,24 @@ describe("Secp256k1.Signature methods", () => {
 			expect(Array.from(parsedFull.r)).toEqual(Array.from(signature.r));
 			expect(Array.from(parsedFull.s)).toEqual(Array.from(signature.s));
 			expect(Array.from(parsedCompact.r)).toEqual(Array.from(signature.r));
+			// s should be preserved for yParity=0
 			expect(Array.from(parsedCompact.s)).toEqual(Array.from(signature.s));
 		});
 
-		it("should handle various byte patterns", () => {
+		it("should handle various byte patterns (without high bit in s)", () => {
+			// Use patterns that don't have bit 255 set in s to test roundtrip
 			const patterns = [
 				{ fill: 0x00, name: "zeros" },
 				{ fill: 0x55, name: "0x55" },
-				{ fill: 0xaa, name: "0xaa" },
-				{ fill: 0xff, name: "ones" },
+				{ fill: 0x2a, name: "0x2a" },
+				{ fill: 0x7f, name: "0x7f" }, // Max without high bit
 			];
 
 			for (const { fill } of patterns) {
 				const signature = {
 					r: new Uint8Array(32).fill(fill),
 					s: new Uint8Array(32).fill(fill),
-					v: 27,
+					v: 27, // yParity = 0
 				};
 
 				const bytes = toBytes(signature);

--- a/src/crypto/Secp256k1/Signature/fromCompact.js
+++ b/src/crypto/Secp256k1/Signature/fromCompact.js
@@ -2,19 +2,27 @@
 import { InvalidSignatureError } from "../../../primitives/errors/index.js";
 
 /**
- * Create signature from compact format (64 bytes: r || s)
+ * Create signature from EIP-2098 compact format (64 bytes: r || s with yParity in bit 255)
  *
+ * EIP-2098 encodes yParity in bit 255 of s. This function:
+ * - Extracts yParity from bit 255 if no explicit v is provided
+ * - Clears bit 255 from s to restore the original s value
+ * - Uses the explicit v if provided (for legacy compatibility)
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-2098
  * @see https://voltaire.tevm.sh/crypto for crypto documentation
  * @since 0.0.0
  * @param {Uint8Array} compact - 64-byte compact signature
- * @param {number} v - Recovery id (0, 1, 27, or 28)
+ * @param {number} [v] - Optional explicit recovery id. If omitted, extracted from bit 255.
  * @returns {import('../SignatureType.js').Secp256k1SignatureType} ECDSA signature
  * @throws {InvalidSignatureError} If compact data is wrong length
  * @example
  * ```javascript
  * import { Secp256k1 } from './crypto/Secp256k1/index.js';
- * const compact = new Uint8Array(64);
- * const signature = Secp256k1.Signature.fromCompact(compact, 27);
+ * // EIP-2098: extract yParity from bit 255
+ * const sig1 = Secp256k1.Signature.fromCompact(compact);
+ * // Explicit v (legacy)
+ * const sig2 = Secp256k1.Signature.fromCompact(compact, 27);
  * ```
  */
 export function fromCompact(compact, v) {
@@ -29,9 +37,19 @@ export function fromCompact(compact, v) {
 		);
 	}
 
+	// EIP-2098: Extract yParity from bit 255 of s
+	const yParityFromBit = (compact[32] & 0x80) >> 7;
+
+	// Use explicit v if provided, otherwise use extracted yParity
+	const recoveryV = v !== undefined ? v : yParityFromBit;
+
+	// Clear bit 255 from s to restore original value
+	const s = compact.slice(32, 64);
+	s[0] = s[0] & 0x7f;
+
 	return {
 		r: compact.slice(0, 32),
-		s: compact.slice(32, 64),
-		v,
+		s,
+		v: recoveryV,
 	};
 }

--- a/src/crypto/Secp256k1/Signature/fromCompact.test.ts
+++ b/src/crypto/Secp256k1/Signature/fromCompact.test.ts
@@ -31,18 +31,18 @@ describe("Secp256k1.Signature.fromCompact", () => {
 			expect(sig.r[31]).toBe(31);
 		});
 
-		it("should extract s component correctly", () => {
+		it("should extract s component correctly and clear bit 255", () => {
 			const compact = new Uint8Array(64);
 			compact.fill(0, 0, 32);
 			for (let i = 0; i < 32; i++) {
-				compact[32 + i] = 100 + i;
+				compact[32 + i] = i; // Use 0-31 to avoid high bit
 			}
 
 			const sig = Signature.fromCompact(compact, 28);
 
-			expect(sig.s[0]).toBe(100);
-			expect(sig.s[1]).toBe(101);
-			expect(sig.s[31]).toBe(131);
+			expect(sig.s[0]).toBe(0); // bit 255 cleared
+			expect(sig.s[1]).toBe(1);
+			expect(sig.s[31]).toBe(31);
 		});
 
 		it("should accept v=27", () => {
@@ -176,14 +176,16 @@ describe("Secp256k1.Signature.fromCompact", () => {
 			expect(sig.s.every((b) => b === 0)).toBe(true);
 		});
 
-		it("should handle max values for r and s", () => {
+		it("should handle max values for r and clear bit 255 from s", () => {
 			const compact = new Uint8Array(64);
 			compact.fill(0xff, 0, 64);
 
 			const sig = Signature.fromCompact(compact, 27);
 
 			expect(sig.r.every((b) => b === 0xff)).toBe(true);
-			expect(sig.s.every((b) => b === 0xff)).toBe(true);
+			// s[0] should have bit 255 cleared (0xff -> 0x7f)
+			expect(sig.s[0]).toBe(0x7f);
+			expect(sig.s.slice(1).every((b) => b === 0xff)).toBe(true);
 		});
 
 		it("should handle large chain ID v values", () => {
@@ -226,26 +228,48 @@ describe("Secp256k1.Signature.fromCompact", () => {
 		});
 	});
 
-	describe("roundtrip with toCompact", () => {
-		it("should roundtrip correctly", () => {
+	describe("roundtrip with toCompact (EIP-2098)", () => {
+		it("should roundtrip correctly for yParity=0", () => {
+			// Use s values without high bit to avoid EIP-2098 encoding
 			const original = new Uint8Array(64);
 			for (let i = 0; i < 32; i++) {
 				original[i] = i;
 			}
 			for (let i = 0; i < 32; i++) {
-				original[32 + i] = 100 + i;
+				original[32 + i] = i; // Use 0-31 to avoid high bit
 			}
 
-			const sig = Signature.fromCompact(original, 27);
+			const sig = Signature.fromCompact(original, 27); // yParity=0
 			const reconstructed = Signature.toCompact(sig);
 
 			expect(reconstructed).toEqual(original);
 		});
 
+		it("should roundtrip correctly for yParity=1", () => {
+			// Use s values without high bit
+			const original = new Uint8Array(64);
+			for (let i = 0; i < 32; i++) {
+				original[i] = i;
+			}
+			for (let i = 0; i < 32; i++) {
+				original[32 + i] = i; // Use 0-31 to avoid high bit
+			}
+
+			const sig = Signature.fromCompact(original, 28); // yParity=1
+			const reconstructed = Signature.toCompact(sig);
+
+			// For yParity=1, bit 255 gets set in toCompact
+			expect(reconstructed[32] & 0x80).toBe(0x80);
+			// But the rest matches after clearing bit 255
+			const expected = new Uint8Array(original);
+			expected[32] |= 0x80;
+			expect(reconstructed).toEqual(expected);
+		});
+
 		it("should preserve v through roundtrip", () => {
 			const compact = new Uint8Array(64);
 			compact.fill(7, 0, 32);
-			compact.fill(13, 32, 64);
+			compact.fill(0x13, 32, 64); // Use low value
 
 			const sig = Signature.fromCompact(compact, 28);
 

--- a/src/crypto/Secp256k1/Signature/toCompact.js
+++ b/src/crypto/Secp256k1/Signature/toCompact.js
@@ -1,35 +1,49 @@
 // @ts-nocheck
 /**
- * Concatenate multiple Uint8Arrays
- * @param {...Uint8Array} arrays
- * @returns {Uint8Array}
- */
-function concat(...arrays) {
-	const totalLength = arrays.reduce((sum, arr) => sum + arr.length, 0);
-	const result = new Uint8Array(totalLength);
-	let offset = 0;
-	for (const arr of arrays) {
-		result.set(arr, offset);
-		offset += arr.length;
-	}
-	return result;
-}
-
-/**
- * Convert signature to compact format (64 bytes: r || s)
+ * Convert signature to EIP-2098 compact format (64 bytes: r || s with yParity in bit 255)
  *
+ * EIP-2098 encodes the recovery parameter (yParity) into the highest bit of s,
+ * allowing signatures to be represented in 64 bytes instead of 65.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-2098
  * @see https://voltaire.tevm.sh/crypto for crypto documentation
  * @since 0.0.0
  * @param {import('../SignatureType.js').Secp256k1SignatureType} signature - ECDSA signature
- * @returns {Uint8Array} 64-byte compact signature
+ * @returns {Uint8Array} 64-byte EIP-2098 compact signature
  * @throws {never}
  * @example
  * ```javascript
  * import { Secp256k1 } from './crypto/Secp256k1/index.js';
  * const compact = Secp256k1.Signature.toCompact(signature);
  * console.log(compact.length); // 64
+ * // yParity is encoded in bit 255 of s
  * ```
  */
 export function toCompact(signature) {
-	return concat(signature.r, signature.s);
+	const compact = new Uint8Array(64);
+
+	// Copy r (first 32 bytes)
+	compact.set(signature.r, 0);
+
+	// Copy s (next 32 bytes)
+	compact.set(signature.s, 32);
+
+	// EIP-2098: Encode yParity in bit 255 (MSB) of s
+	// Convert v to yParity (0 or 1)
+	// v can be: 0/1 (yParity), 27/28 (legacy), or chainId*2+35+yParity (EIP-155)
+	let yParity;
+	if (signature.v <= 1) {
+		yParity = signature.v;
+	} else if (signature.v === 27 || signature.v === 28) {
+		yParity = signature.v - 27;
+	} else {
+		// EIP-155: v = chainId * 2 + 35 + yParity
+		yParity = (signature.v - 35) % 2;
+	}
+
+	if (yParity === 1) {
+		compact[32] |= 0x80; // Set bit 255
+	}
+
+	return compact;
 }

--- a/src/crypto/Secp256k1/Signature/toCompact.test.ts
+++ b/src/crypto/Secp256k1/Signature/toCompact.test.ts
@@ -3,7 +3,7 @@ import { Hash } from "../../../primitives/Hash/index.js";
 import * as Signature from "./index.js";
 
 describe("Secp256k1.Signature.toCompact", () => {
-	describe("conversion to compact format", () => {
+	describe("EIP-2098 compact format", () => {
 		it("should convert signature to 64-byte array", () => {
 			const r = Hash.from(new Uint8Array(32).fill(1));
 			const s = Hash.from(new Uint8Array(32).fill(2));
@@ -25,27 +25,41 @@ describe("Secp256k1.Signature.toCompact", () => {
 			expect(compact.slice(0, 32).every((b) => b === 42)).toBe(true);
 		});
 
-		it("should place s in bytes 32-63", () => {
+		it("should place s in bytes 32-63 with yParity in bit 255", () => {
 			const r = Hash.from(new Uint8Array(32).fill(42));
-			const s = Hash.from(new Uint8Array(32).fill(99));
-			const sig = { r, s, v: 27 };
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const sig = { r, s, v: 27 }; // yParity = 0
 
 			const compact = Signature.toCompact(sig);
 
-			expect(compact.slice(32, 64).every((b) => b === 99)).toBe(true);
+			// s[0] should be 0x55 (bit 255 clear for yParity=0)
+			expect(compact[32]).toBe(0x55);
+			expect(compact.slice(33, 64).every((b) => b === 0x55)).toBe(true);
 		});
 
-		it("should not include v in compact format", () => {
+		it("should encode yParity=0 (v=27) with bit 255 clear", () => {
 			const r = Hash.from(new Uint8Array(32).fill(1));
-			const s = Hash.from(new Uint8Array(32).fill(2));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
 			const sig = { r, s, v: 27 };
 
 			const compact = Signature.toCompact(sig);
 
-			expect(compact.length).toBe(64);
+			expect(compact[32] & 0x80).toBe(0x00); // Bit 255 clear
+			expect(compact[32] & 0x7f).toBe(0x55); // Original s preserved
 		});
 
-		it("should produce same compact for different v values", () => {
+		it("should encode yParity=1 (v=28) with bit 255 set", () => {
+			const r = Hash.from(new Uint8Array(32).fill(1));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const sig = { r, s, v: 28 };
+
+			const compact = Signature.toCompact(sig);
+
+			expect(compact[32] & 0x80).toBe(0x80); // Bit 255 set
+			expect(compact[32] & 0x7f).toBe(0x55); // Original s preserved
+		});
+
+		it("should produce different compact for different v values (EIP-2098)", () => {
 			const r = Hash.from(new Uint8Array(32).fill(7));
 			const s = Hash.from(new Uint8Array(32).fill(13));
 			const sig27 = { r, s, v: 27 };
@@ -54,7 +68,10 @@ describe("Secp256k1.Signature.toCompact", () => {
 			const compact27 = Signature.toCompact(sig27);
 			const compact28 = Signature.toCompact(sig28);
 
-			expect(compact27).toEqual(compact28);
+			// Should differ in bit 255 of s
+			expect(compact27[32] & 0x80).toBe(0x00);
+			expect(compact28[32] & 0x80).toBe(0x80);
+			expect(compact27).not.toEqual(compact28);
 		});
 	});
 
@@ -69,7 +86,7 @@ describe("Secp256k1.Signature.toCompact", () => {
 			expect(compact.slice(0, 32).every((b) => b === 0)).toBe(true);
 		});
 
-		it("should handle all-zero s", () => {
+		it("should handle all-zero s with yParity=0", () => {
 			const r = Hash.from(new Uint8Array(32).fill(1));
 			const s = Hash.from(new Uint8Array(32));
 			const sig = { r, s, v: 27 };
@@ -79,35 +96,71 @@ describe("Secp256k1.Signature.toCompact", () => {
 			expect(compact.slice(32, 64).every((b) => b === 0)).toBe(true);
 		});
 
-		it("should handle max values for r and s", () => {
+		it("should handle all-zero s with yParity=1", () => {
+			const r = Hash.from(new Uint8Array(32).fill(1));
+			const s = Hash.from(new Uint8Array(32));
+			const sig = { r, s, v: 28 };
+
+			const compact = Signature.toCompact(sig);
+
+			// First byte of s should have bit 255 set
+			expect(compact[32]).toBe(0x80);
+			expect(compact.slice(33, 64).every((b) => b === 0)).toBe(true);
+		});
+
+		it("should handle max values for r (s will have bit 255 set based on yParity)", () => {
 			const r = Hash.from(new Uint8Array(32).fill(0xff));
-			const s = Hash.from(new Uint8Array(32).fill(0xff));
-			const sig = { r, s, v: 27 };
+			const s = Hash.from(new Uint8Array(32).fill(0x7f)); // Use 0x7f to avoid collision with yParity bit
+			const sig = { r, s, v: 27 }; // yParity = 0
 
 			const compact = Signature.toCompact(sig);
 
 			expect(compact.slice(0, 32).every((b) => b === 0xff)).toBe(true);
-			expect(compact.slice(32, 64).every((b) => b === 0xff)).toBe(true);
+			expect(compact[32]).toBe(0x7f); // Bit 255 clear for yParity=0
 		});
 
-		it("should handle v=0", () => {
+		it("should handle v=0 (yParity=0)", () => {
 			const r = Hash.from(new Uint8Array(32).fill(1));
-			const s = Hash.from(new Uint8Array(32).fill(2));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
 			const sig = { r, s, v: 0 };
 
 			const compact = Signature.toCompact(sig);
 
 			expect(compact.length).toBe(64);
+			expect(compact[32] & 0x80).toBe(0x00); // Bit 255 clear
 		});
 
-		it("should handle EIP-155 v values", () => {
+		it("should handle v=1 (yParity=1)", () => {
 			const r = Hash.from(new Uint8Array(32).fill(1));
-			const s = Hash.from(new Uint8Array(32).fill(2));
-			const sig = { r, s, v: 37 };
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const sig = { r, s, v: 1 };
 
 			const compact = Signature.toCompact(sig);
 
 			expect(compact.length).toBe(64);
+			expect(compact[32] & 0x80).toBe(0x80); // Bit 255 set
+		});
+
+		it("should handle EIP-155 v=37 (chainId=1, yParity=0)", () => {
+			const r = Hash.from(new Uint8Array(32).fill(1));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const sig = { r, s, v: 37 }; // (37-35) % 2 = 0
+
+			const compact = Signature.toCompact(sig);
+
+			expect(compact.length).toBe(64);
+			expect(compact[32] & 0x80).toBe(0x00); // Bit 255 clear
+		});
+
+		it("should handle EIP-155 v=38 (chainId=1, yParity=1)", () => {
+			const r = Hash.from(new Uint8Array(32).fill(1));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const sig = { r, s, v: 38 }; // (38-35) % 2 = 1
+
+			const compact = Signature.toCompact(sig);
+
+			expect(compact.length).toBe(64);
+			expect(compact[32] & 0x80).toBe(0x80); // Bit 255 set
 		});
 	});
 
@@ -143,32 +196,59 @@ describe("Secp256k1.Signature.toCompact", () => {
 		});
 	});
 
-	describe("roundtrip with fromCompact", () => {
-		it("should roundtrip correctly (without v)", () => {
+	describe("roundtrip with fromCompact (EIP-2098)", () => {
+		it("should roundtrip correctly with yParity=0", () => {
 			const r = Hash.from(new Uint8Array(32).fill(7));
-			const s = Hash.from(new Uint8Array(32).fill(13));
-			const original = { r, s, v: 27 };
+			const s = Hash.from(new Uint8Array(32).fill(0x13)); // Use value < 0x80
+			const original = { r, s, v: 27 }; // yParity = 0
 
 			const compact = Signature.toCompact(original);
-			const reconstructed = Signature.fromCompact(compact, 27);
+			const reconstructed = Signature.fromCompact(compact, 0); // Use yParity 0
 
 			expect(new Uint8Array(reconstructed.r)).toEqual(
 				new Uint8Array(original.r),
 			);
+			// s is unchanged for yParity=0 (bit 255 clear)
 			expect(new Uint8Array(reconstructed.s)).toEqual(
 				new Uint8Array(original.s),
 			);
+			expect(reconstructed.v).toBe(0); // yParity 0
 		});
 
-		it("should lose v information in compact format", () => {
-			const r = Hash.from(new Uint8Array(32).fill(1));
-			const s = Hash.from(new Uint8Array(32).fill(2));
-			const original = { r, s, v: 28 };
+		it("should roundtrip correctly with yParity=1 (EIP-2098 compliant)", () => {
+			const r = Hash.from(new Uint8Array(32).fill(7));
+			const s = Hash.from(new Uint8Array(32).fill(0x13)); // Use value < 0x80
+			const original = { r, s, v: 28 }; // yParity = 1
 
 			const compact = Signature.toCompact(original);
-			const reconstructed = Signature.fromCompact(compact, 27);
 
-			expect(reconstructed.v).toBe(27); // Not 28
+			// Verify yParity is encoded in bit 255 of compact
+			expect(compact[32] & 0x80).toBe(0x80);
+
+			// fromCompact clears bit 255 from s and extracts yParity
+			const reconstructed = Signature.fromCompact(compact, 1);
+
+			// r should match
+			expect(new Uint8Array(reconstructed.r)).toEqual(
+				new Uint8Array(original.r),
+			);
+			// s should match (bit 255 cleared by fromCompact)
+			expect(new Uint8Array(reconstructed.s)).toEqual(
+				new Uint8Array(original.s),
+			);
+			expect(reconstructed.v).toBe(1);
+		});
+
+		it("should preserve yParity in EIP-2098 format", () => {
+			const r = Hash.from(new Uint8Array(32).fill(1));
+			const s = Hash.from(new Uint8Array(32).fill(0x55));
+			const original = { r, s, v: 28 }; // yParity = 1
+
+			const compact = Signature.toCompact(original);
+
+			// Verify yParity is encoded in bit 255
+			expect(compact[32] & 0x80).toBe(0x80);
+			expect(compact[32] & 0x7f).toBe(0x55); // Original s value preserved
 		});
 	});
 
@@ -259,14 +339,31 @@ describe("Secp256k1.Signature.toCompact", () => {
 	});
 
 	describe("comparison with toBytes", () => {
-		it("should match first 64 bytes of toBytes", () => {
+		it("should differ from toBytes due to EIP-2098 yParity encoding for v=28", () => {
 			const r = Hash.from(new Uint8Array(32).fill(7));
-			const s = Hash.from(new Uint8Array(32).fill(13));
-			const sig = { r, s, v: 27 };
+			const s = Hash.from(new Uint8Array(32).fill(0x13));
+			const sig = { r, s, v: 28 }; // yParity = 1
 
 			const compact = Signature.toCompact(sig);
 			const bytes = Signature.toBytes(sig);
 
+			// r should match
+			expect(compact.slice(0, 32)).toEqual(bytes.slice(0, 32));
+
+			// s in compact has bit 255 set, bytes does not
+			expect(compact[32] & 0x80).toBe(0x80); // yParity encoded
+			expect(bytes[32] & 0x80).toBe(0x00); // No yParity encoding
+		});
+
+		it("should match toBytes for v=27 (yParity=0, no bit 255 modification)", () => {
+			const r = Hash.from(new Uint8Array(32).fill(7));
+			const s = Hash.from(new Uint8Array(32).fill(0x13));
+			const sig = { r, s, v: 27 }; // yParity = 0
+
+			const compact = Signature.toCompact(sig);
+			const bytes = Signature.toBytes(sig);
+
+			// For yParity=0, compact and bytes[:64] should match
 			expect(compact).toEqual(bytes.slice(0, 64));
 		});
 	});


### PR DESCRIPTION
## Summary
- Fixes #143
- Updated toCompact() to encode yParity in bit 255 of s per EIP-2098
- Updated fromCompact() to extract yParity from bit 255
- Added comprehensive tests

## Test plan
- [x] Compact format roundtrip works
- [x] Bit 255 encoding/decoding correct
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)