### PR TITLE
🐛 fix: Add input validation to PublicKey.compress()

### DIFF
--- a/src/primitives/PublicKey/compress.js
+++ b/src/primitives/PublicKey/compress.js
@@ -1,3 +1,5 @@
+import { InvalidLengthError } from "../errors/ValidationError.js";
+
 /**
  * Compress a public key from 64 bytes (uncompressed) to 33 bytes (compressed)
  *
@@ -6,6 +8,7 @@
  *
  * @param {import('./PublicKeyType.js').PublicKeyType} publicKey - Uncompressed public key (64 bytes)
  * @returns {Uint8Array} Compressed public key (33 bytes)
+ * @throws {InvalidLengthError} If public key is not 64 bytes
  *
  * @example
  * ```javascript
@@ -14,6 +17,19 @@
  * ```
  */
 export function compress(publicKey) {
+	// Validate input length
+	if (publicKey.length !== 64) {
+		throw new InvalidLengthError(
+			`Invalid public key length: expected 64 bytes, got ${publicKey.length}`,
+			{
+				value: publicKey.length,
+				expected: "64 bytes (uncompressed public key without 0x04 prefix)",
+				code: "PUBLIC_KEY_INVALID_LENGTH",
+				docsPath: "/primitives/public-key/compress#error-handling",
+			},
+		);
+	}
+
 	const result = new Uint8Array(33);
 
 	// Parse y coordinate to determine parity

--- a/src/primitives/PublicKey/compress.test.ts
+++ b/src/primitives/PublicKey/compress.test.ts
@@ -1,7 +1,68 @@
 import { describe, expect, test } from "vitest";
+import { InvalidLengthError } from "../errors/ValidationError.js";
 import * as PublicKey from "./index.js";
 
 describe("PublicKey.compress", () => {
+	describe("validation", () => {
+		test("throws InvalidLengthError for empty input", () => {
+			const empty = new Uint8Array(0);
+			expect(() => PublicKey.compress(empty)).toThrow(InvalidLengthError);
+			expect(() => PublicKey.compress(empty)).toThrow(
+				/expected 64 bytes, got 0/,
+			);
+		});
+
+		test("throws InvalidLengthError for 33-byte compressed key", () => {
+			const compressed = new Uint8Array(33);
+			compressed[0] = 0x02;
+			expect(() => PublicKey.compress(compressed)).toThrow(InvalidLengthError);
+			expect(() => PublicKey.compress(compressed)).toThrow(
+				/expected 64 bytes, got 33/,
+			);
+		});
+
+		test("throws InvalidLengthError for 65-byte prefixed key", () => {
+			// 65-byte format with 0x04 prefix - user should strip prefix first
+			const prefixed = new Uint8Array(65);
+			prefixed[0] = 0x04;
+			expect(() => PublicKey.compress(prefixed)).toThrow(InvalidLengthError);
+			expect(() => PublicKey.compress(prefixed)).toThrow(
+				/expected 64 bytes, got 65/,
+			);
+		});
+
+		test("throws InvalidLengthError for 32-byte input", () => {
+			const short = new Uint8Array(32);
+			expect(() => PublicKey.compress(short)).toThrow(InvalidLengthError);
+			expect(() => PublicKey.compress(short)).toThrow(
+				/expected 64 bytes, got 32/,
+			);
+		});
+
+		test("throws InvalidLengthError for 128-byte input", () => {
+			const long = new Uint8Array(128);
+			expect(() => PublicKey.compress(long)).toThrow(InvalidLengthError);
+			expect(() => PublicKey.compress(long)).toThrow(
+				/expected 64 bytes, got 128/,
+			);
+		});
+
+		test("error has correct code and docsPath", () => {
+			const invalid = new Uint8Array(10);
+			try {
+				PublicKey.compress(invalid);
+				expect.fail("Should have thrown");
+			} catch (e) {
+				expect((e as InvalidLengthError).code).toBe(
+					"PUBLIC_KEY_INVALID_LENGTH",
+				);
+				expect((e as InvalidLengthError).docsPath).toBe(
+					"/primitives/public-key/compress#error-handling",
+				);
+			}
+		});
+	});
+
 	test("compresses known public key", () => {
 		// Known test vector - generator point
 		const uncompressed =


### PR DESCRIPTION
## Summary
- Fixes #142
- Added length validation (must be exactly 64 bytes)
- Throws InvalidLengthError for invalid input
- Added 6 validation tests

## Test plan
- [x] Empty input rejected
- [x] Compressed keys (33 bytes) rejected
- [x] Prefixed keys (65 bytes) rejected
- [x] Short/long input rejected

🤖 Generated with [Claude Code](https://claude.ai/code)