### PR TITLE
🎉 feat: Add Abi.findSelectorCollisions() for collision detection

### DIFF
--- a/src/primitives/Abi/Abi.js
+++ b/src/primitives/Abi/Abi.js
@@ -10,6 +10,10 @@ import {
 import { encode } from "./encode.js";
 import * as ErrorNs from "./error/index.js";
 import * as EventNs from "./event/index.js";
+import {
+	findSelectorCollisions,
+	hasSelectorCollisions,
+} from "./findSelectorCollisions.js";
 import { format } from "./format.js";
 import { formatWithArgs } from "./formatWithArgs.js";
 import * as FunctionNs from "./function/index.js";
@@ -55,6 +59,8 @@ Abi.encode = encode;
 Abi.decode = decode;
 Abi.decodeData = decodeData;
 Abi.parseLogs = parseLogs;
+Abi.findSelectorCollisions = findSelectorCollisions;
+Abi.hasSelectorCollisions = hasSelectorCollisions;
 
 // Parameter encoding/decoding methods
 Abi.encodeParameters = encodeParameters;
@@ -150,6 +156,14 @@ Abi.prototype.getReceive = function () {
 	return /** @type {*} */ (this).find(
 		/** @param {*} item */ (item) => item.type === "receive",
 	);
+};
+
+Abi.prototype.findSelectorCollisions = function () {
+	return findSelectorCollisions(/** @type {*} */ (this));
+};
+
+Abi.prototype.hasSelectorCollisions = function () {
+	return hasSelectorCollisions(/** @type {*} */ (this));
 };
 
 Abi.prototype[Symbol.for("nodejs.util.inspect.custom")] = function (

--- a/src/primitives/Abi/findSelectorCollisions.js
+++ b/src/primitives/Abi/findSelectorCollisions.js
@@ -1,0 +1,97 @@
+// @ts-check
+
+import * as Hex from "../Hex/index.js";
+// biome-ignore lint/suspicious/noShadowRestrictedNames: Function is the ABI namespace
+import * as Function from "./function/index.js";
+
+/**
+ * @typedef {Object} SelectorCollision
+ * @property {import("../Hex/index.js").HexType} selector - The colliding 4-byte selector
+ * @property {import('./function/FunctionType.js').FunctionType[]} functions - Functions sharing this selector
+ */
+
+/**
+ * Find function selector collisions in an ABI
+ *
+ * Detects when multiple functions in an ABI have the same 4-byte selector.
+ * This can happen due to the birthday paradox with 4-byte hashes (~77,000 functions → 50% collision chance).
+ *
+ * @param {import('./Item/ItemType.js').ItemType[]} abi - ABI to check
+ * @returns {SelectorCollision[]} Array of collisions (empty if none found)
+ *
+ * @see https://voltaire.tevm.sh/primitives/abi
+ * @since 0.1.42
+ * @example
+ * ```javascript
+ * import { Abi } from './primitives/Abi/index.js';
+ *
+ * // ABI with potential collision
+ * const abi = [
+ *   { type: "function", name: "transfer", inputs: [{ type: "address" }, { type: "uint256" }] },
+ *   { type: "function", name: "transfer", inputs: [{ type: "address" }, { type: "uint256" }] }
+ * ];
+ *
+ * const collisions = Abi.findSelectorCollisions(abi);
+ * if (collisions.length > 0) {
+ *   console.warn("Selector collisions detected:", collisions);
+ * }
+ * ```
+ */
+export function findSelectorCollisions(abi) {
+	/** @type {Map<string, import('./function/FunctionType.js').FunctionType[]>} */
+	const selectorMap = new Map();
+
+	// Group functions by selector
+	for (const item of abi) {
+		if (item.type !== "function") continue;
+
+		const fn = /** @type {import('./function/FunctionType.js').FunctionType} */ (
+			item
+		);
+		const selectorBytes = Function.getSelector(fn);
+		const selectorHex = Hex.fromBytes(selectorBytes);
+
+		const existing = selectorMap.get(selectorHex);
+		if (existing) {
+			existing.push(fn);
+		} else {
+			selectorMap.set(selectorHex, [fn]);
+		}
+	}
+
+	// Find collisions (selectors with more than one function)
+	/** @type {SelectorCollision[]} */
+	const collisions = [];
+
+	for (const [selector, functions] of selectorMap) {
+		if (functions.length > 1) {
+			collisions.push({
+				selector: /** @type {import("../Hex/index.js").HexType} */ (selector),
+				functions,
+			});
+		}
+	}
+
+	return collisions;
+}
+
+/**
+ * Check if an ABI has any function selector collisions
+ *
+ * @param {import('./Item/ItemType.js').ItemType[]} abi - ABI to check
+ * @returns {boolean} True if collisions exist
+ *
+ * @see https://voltaire.tevm.sh/primitives/abi
+ * @since 0.1.42
+ * @example
+ * ```javascript
+ * import { Abi } from './primitives/Abi/index.js';
+ *
+ * if (Abi.hasSelectorCollisions(abi)) {
+ *   throw new Error("ABI contains function selector collisions");
+ * }
+ * ```
+ */
+export function hasSelectorCollisions(abi) {
+	return findSelectorCollisions(abi).length > 0;
+}

--- a/src/primitives/Abi/findSelectorCollisions.test.ts
+++ b/src/primitives/Abi/findSelectorCollisions.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { findSelectorCollisions, hasSelectorCollisions } from "./findSelectorCollisions.js";
+
+describe("findSelectorCollisions", () => {
+	it("returns empty array for ABI with no collisions", () => {
+		const abi = [
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [{ type: "bool" }],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "balanceOf",
+				inputs: [{ type: "address", name: "account" }],
+				outputs: [{ type: "uint256" }],
+				stateMutability: "view" as const,
+			},
+		];
+
+		const collisions = findSelectorCollisions(abi);
+		expect(collisions).toEqual([]);
+	});
+
+	it("detects duplicate functions (same signature)", () => {
+		const abi = [
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [{ type: "bool" }],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "recipient" },
+					{ type: "uint256", name: "value" },
+				],
+				outputs: [{ type: "bool" }],
+				stateMutability: "nonpayable" as const,
+			},
+		];
+
+		const collisions = findSelectorCollisions(abi);
+		expect(collisions.length).toBe(1);
+		expect(collisions[0].selector).toBe("0xa9059cbb"); // transfer(address,uint256)
+		expect(collisions[0].functions.length).toBe(2);
+	});
+
+	it("ignores non-function items", () => {
+		const abi = [
+			{
+				type: "event" as const,
+				name: "Transfer",
+				inputs: [
+					{ type: "address", name: "from", indexed: true },
+					{ type: "address", name: "to", indexed: true },
+					{ type: "uint256", name: "value" },
+				],
+			},
+			{
+				type: "error" as const,
+				name: "InsufficientBalance",
+				inputs: [{ type: "uint256", name: "balance" }],
+			},
+		];
+
+		const collisions = findSelectorCollisions(abi);
+		expect(collisions).toEqual([]);
+	});
+
+	it("handles empty ABI", () => {
+		const collisions = findSelectorCollisions([]);
+		expect(collisions).toEqual([]);
+	});
+
+	it("detects multiple collision groups", () => {
+		const abi = [
+			// First collision group: transfer(address,uint256)
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "recipient" },
+					{ type: "uint256", name: "value" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			// Second collision group: approve(address,uint256)
+			{
+				type: "function" as const,
+				name: "approve",
+				inputs: [
+					{ type: "address", name: "spender" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "approve",
+				inputs: [
+					{ type: "address", name: "delegate" },
+					{ type: "uint256", name: "value" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+		];
+
+		const collisions = findSelectorCollisions(abi);
+		expect(collisions.length).toBe(2);
+	});
+
+	it("detects three functions with same selector", () => {
+		const abi = [
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "recipient" },
+					{ type: "uint256", name: "value" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "dest" },
+					{ type: "uint256", name: "qty" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+		];
+
+		const collisions = findSelectorCollisions(abi);
+		expect(collisions.length).toBe(1);
+		expect(collisions[0].functions.length).toBe(3);
+	});
+});
+
+describe("hasSelectorCollisions", () => {
+	it("returns false for ABI with no collisions", () => {
+		const abi = [
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+		];
+
+		expect(hasSelectorCollisions(abi)).toBe(false);
+	});
+
+	it("returns true when collisions exist", () => {
+		const abi = [
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "to" },
+					{ type: "uint256", name: "amount" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+			{
+				type: "function" as const,
+				name: "transfer",
+				inputs: [
+					{ type: "address", name: "recipient" },
+					{ type: "uint256", name: "value" },
+				],
+				outputs: [],
+				stateMutability: "nonpayable" as const,
+			},
+		];
+
+		expect(hasSelectorCollisions(abi)).toBe(true);
+	});
+
+	it("returns false for empty ABI", () => {
+		expect(hasSelectorCollisions([])).toBe(false);
+	});
+});

--- a/src/primitives/Abi/index.ts
+++ b/src/primitives/Abi/index.ts
@@ -18,6 +18,10 @@ export * as Error from "./error/index.js";
 export * from "./error/standards/index.js";
 export * from "./error/wrapped/index.js";
 export * as Event from "./event/index.js";
+export {
+	findSelectorCollisions,
+	hasSelectorCollisions,
+} from "./findSelectorCollisions.js";
 // Re-export sub-namespaces for runtime (Abi.Function.*, Abi.Event.*, etc.)
 export * as Function from "./function/index.js";
 export * as Item from "./Item/index.js";


### PR DESCRIPTION
## Summary
- Fixes #134
- Added `findSelectorCollisions()` returning collision details
- Added `hasSelectorCollisions()` for quick boolean check
- Works as both static and instance methods

## Test plan
- [x] No collisions case
- [x] Duplicate function detection
- [x] Multiple collision groups
- [x] 3+ functions same selector

🤖 Generated with [Claude Code](https://claude.ai/code)