### PR TITLE
🐛 fix: Add uint64 max validation to WithdrawalIndex

### DIFF
--- a/src/primitives/Withdrawal/Withdrawal.test.ts
+++ b/src/primitives/Withdrawal/Withdrawal.test.ts
@@ -43,6 +43,29 @@ describe("Withdrawal", () => {
 			expect(withdrawal.address.length).toBe(20);
 		});
 
+		it("accepts uint64 max index (EIP-4895 compliance)", () => {
+			const UINT64_MAX = 18446744073709551615n;
+			const withdrawal = Withdrawal.from({
+				index: UINT64_MAX,
+				validatorIndex: 123456,
+				address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+				amount: 32000000000n,
+			});
+			expect(withdrawal.index).toBe(UINT64_MAX);
+		});
+
+		it("rejects index exceeding uint64 max", () => {
+			const UINT64_MAX = 18446744073709551615n;
+			expect(() =>
+				Withdrawal.from({
+					index: UINT64_MAX + 1n,
+					validatorIndex: 123456,
+					address: "0x742d35Cc6634C0532925a3b844Bc9e7595f251e3",
+					amount: 32000000000n,
+				}),
+			).toThrow("exceeds uint64 max");
+		});
+
 		it("rejects invalid index", () => {
 			expect(() =>
 				Withdrawal.from({

--- a/src/primitives/WithdrawalIndex/WithdrawalIndex.test.ts
+++ b/src/primitives/WithdrawalIndex/WithdrawalIndex.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import * as WithdrawalIndex from "./index.js";
 
 describe("WithdrawalIndex", () => {
+	describe("UINT64_MAX", () => {
+		it("equals 2^64 - 1", () => {
+			expect(WithdrawalIndex.UINT64_MAX).toBe(18446744073709551615n);
+			expect(WithdrawalIndex.UINT64_MAX).toBe(2n ** 64n - 1n);
+		});
+	});
+
 	describe("from", () => {
 		it("creates WithdrawalIndex from bigint", () => {
 			const idx = WithdrawalIndex.from(1000000n);
@@ -21,6 +28,28 @@ describe("WithdrawalIndex", () => {
 		it("creates WithdrawalIndex from decimal string", () => {
 			const idx = WithdrawalIndex.from("1000000");
 			expect(idx).toBe(1000000n);
+		});
+
+		it("accepts uint64 max value", () => {
+			const idx = WithdrawalIndex.from(WithdrawalIndex.UINT64_MAX);
+			expect(idx).toBe(18446744073709551615n);
+		});
+
+		it("accepts uint64 max value from hex string", () => {
+			const idx = WithdrawalIndex.from("0xffffffffffffffff");
+			expect(idx).toBe(18446744073709551615n);
+		});
+
+		it("rejects value exceeding uint64 max", () => {
+			expect(() =>
+				WithdrawalIndex.from(WithdrawalIndex.UINT64_MAX + 1n),
+			).toThrow("exceeds uint64 max");
+		});
+
+		it("rejects large value exceeding uint64 max from string", () => {
+			expect(() => WithdrawalIndex.from("0x10000000000000000")).toThrow(
+				"exceeds uint64 max",
+			);
 		});
 
 		it("rejects negative number", () => {

--- a/src/primitives/WithdrawalIndex/from.js
+++ b/src/primitives/WithdrawalIndex/from.js
@@ -1,11 +1,18 @@
 /**
+ * Maximum value for uint64 (2^64 - 1)
+ * Per EIP-4895, withdrawal index is a uint64
+ */
+export const UINT64_MAX = 18446744073709551615n;
+
+/**
  * Create WithdrawalIndex from number, bigint, or string
  *
  * @see https://voltaire.tevm.sh/primitives/withdrawal-index for WithdrawalIndex documentation
+ * @see https://eips.ethereum.org/EIPS/eip-4895 for EIP-4895 specification
  * @since 0.0.0
  * @param {number | bigint | string} value - Withdrawal index (number, bigint, or decimal/hex string)
  * @returns {import('./WithdrawalIndexType.js').WithdrawalIndexType} WithdrawalIndex value
- * @throws {Error} If value is negative or invalid
+ * @throws {Error} If value is negative, exceeds uint64 max, or invalid
  * @example
  * ```javascript
  * import * as WithdrawalIndex from './primitives/WithdrawalIndex/index.js';
@@ -33,6 +40,12 @@ export function from(value) {
 
 	if (bigintValue < 0n) {
 		throw new Error(`WithdrawalIndex value cannot be negative: ${bigintValue}`);
+	}
+
+	if (bigintValue > UINT64_MAX) {
+		throw new Error(
+			`WithdrawalIndex value exceeds uint64 max (${UINT64_MAX}): ${bigintValue}`,
+		);
 	}
 
 	return /** @type {import('./WithdrawalIndexType.js').WithdrawalIndexType} */ (

--- a/src/primitives/WithdrawalIndex/index.ts
+++ b/src/primitives/WithdrawalIndex/index.ts
@@ -1,15 +1,16 @@
 export type { WithdrawalIndexType } from "./WithdrawalIndexType.js";
 
 import { equals } from "./equals.js";
-import { from } from "./from.js";
+import { from, UINT64_MAX } from "./from.js";
 import { toBigInt } from "./toBigInt.js";
 import { toNumber } from "./toNumber.js";
 
-export { from, toNumber, toBigInt, equals };
+export { from, toNumber, toBigInt, equals, UINT64_MAX };
 
 export const WithdrawalIndex = {
 	from,
 	toNumber,
 	toBigInt,
 	equals,
+	UINT64_MAX,
 };


### PR DESCRIPTION
## Summary
- Fixes #128
- Added UINT64_MAX constant and validation
- Values exceeding 2^64-1 now throw error
- Added boundary tests

## Test plan
- [x] uint64 max accepted
- [x] Values beyond uint64 max rejected
- [x] EIP-4895 compliance tests

🤖 Generated with [Claude Code](https://claude.ai/code)