### PR TITLE
🐛 fix: Complete HDKey derivation path validation

### DIFF
--- a/src/crypto/HDWallet/HDWallet.test.ts
+++ b/src/crypto/HDWallet/HDWallet.test.ts
@@ -609,12 +609,15 @@ describe("HDWallet", () => {
 			expect(HDWallet.isValidPath("m/44'/60'/a'/0/0")).toBe(false);
 		});
 
-		it("rejects extremely long paths", () => {
-			// Build a path with 1000 levels
-			const longPath = `m/${Array.from({ length: 1000 }, (_, i) => i).join("/")}`;
-			// Should handle gracefully (either accept or reject, but not crash)
-			const result = HDWallet.isValidPath(longPath);
-			expect(typeof result).toBe("boolean");
+		it("rejects paths exceeding 255 levels (BIP-32 max depth)", () => {
+			// Build a path with 256 levels (exceeds max)
+			const longPath = `m/${Array.from({ length: 256 }, (_, i) => i).join("/")}`;
+			expect(HDWallet.isValidPath(longPath)).toBe(false);
+		});
+
+		it("accepts paths at exactly 255 levels (BIP-32 max depth)", () => {
+			const maxPath = `m/${Array.from({ length: 255 }, (_, i) => i).join("/")}`;
+			expect(HDWallet.isValidPath(maxPath)).toBe(true);
 		});
 
 		it("rejects path with trailing slash", () => {
@@ -631,12 +634,10 @@ describe("HDWallet", () => {
 			expect(HDWallet.isValidPath("m /44'/60'/0'/0/0")).toBe(false);
 		});
 
-		it("rejects path with mixed hardened notation", () => {
-			// Some implementations might not allow mixing ' and h
-			const mixed = "m/0'/1h/2'";
-			const result = HDWallet.isValidPath(mixed);
-			// Should handle consistently (either accept or reject)
-			expect(typeof result).toBe("boolean");
+		it("rejects 'h' hardened notation (@scure/bip32 only supports apostrophe)", () => {
+			// @scure/bip32 doesn't support 'h' notation
+			expect(HDWallet.isValidPath("m/0'/1h/2'")).toBe(false);
+			expect(HDWallet.isValidPath("m/44h/60h/0h/0/0")).toBe(false);
 		});
 
 		it("validates single-level path", () => {
@@ -644,12 +645,42 @@ describe("HDWallet", () => {
 			expect(HDWallet.isValidPath("m/0'")).toBe(true);
 		});
 
-		it("handles root path 'm'", () => {
-			// Root path may or may not be valid depending on implementation
-			const isValid = HDWallet.isValidPath("m");
-			expect(typeof isValid).toBe("boolean");
-			// Trailing slash should definitely be invalid
+		it("rejects root path 'm' (requires at least one derivation level)", () => {
+			expect(HDWallet.isValidPath("m")).toBe(false);
 			expect(HDWallet.isValidPath("m/")).toBe(false);
+		});
+
+		it("rejects index overflow (indices must be < 2^31)", () => {
+			// 2^31 = 2147483648, exceeds max normal index
+			expect(HDWallet.isValidPath("m/2147483648")).toBe(false);
+			expect(HDWallet.isValidPath("m/2147483648'")).toBe(false);
+			// Max valid is 2^31-1 = 2147483647
+			expect(HDWallet.isValidPath("m/2147483647")).toBe(true);
+			expect(HDWallet.isValidPath("m/2147483647'")).toBe(true);
+		});
+
+		it("rejects extremely large indices that would overflow", () => {
+			expect(HDWallet.isValidPath("m/9999999999999")).toBe(false);
+			expect(HDWallet.isValidPath("m/99999999999999999999")).toBe(false);
+		});
+
+		it("validates uppercase M prefix", () => {
+			expect(HDWallet.isValidPath("M/44'/60'/0'/0/0")).toBe(true);
+		});
+
+		it("rejects negative indices", () => {
+			// Regex doesn't match negative numbers
+			expect(HDWallet.isValidPath("m/-1")).toBe(false);
+			expect(HDWallet.isValidPath("m/0/-1")).toBe(false);
+		});
+
+		it("rejects decimal indices", () => {
+			expect(HDWallet.isValidPath("m/1.5")).toBe(false);
+			expect(HDWallet.isValidPath("m/0.5'/1")).toBe(false);
+		});
+
+		it("rejects hex notation", () => {
+			expect(HDWallet.isValidPath("m/0x44'/0x60'/0'/0/0")).toBe(false);
 		});
 	});
 

--- a/src/crypto/HDWallet/isValidPath.js
+++ b/src/crypto/HDWallet/isValidPath.js
@@ -1,21 +1,88 @@
 /**
+ * Maximum index value for non-hardened derivation (2^31 - 1).
+ * @type {number}
+ */
+const MAX_NORMAL_INDEX = 0x7fffffff;
+
+/**
+ * Maximum derivation depth allowed by BIP-32.
+ * @type {number}
+ */
+const MAX_DEPTH = 255;
+
+/**
  * Validate BIP-32 derivation path format.
  *
- * Checks syntax but not semantic validity.
+ * Validates:
+ * - Path starts with 'm/' or 'M/' (case-insensitive)
+ * - Each component is a valid non-negative integer
+ * - Normal indices are < 2^31 (hardened indices are unlimited up to 2^31-1 + offset)
+ * - Hardened notation uses ' (apostrophe) only (@scure/bip32 doesn't support 'h')
+ * - Path depth doesn't exceed 255 levels
+ * - No double slashes, trailing slashes, or invalid characters
  *
  * @see https://voltaire.tevm.sh/crypto for crypto documentation
  * @since 0.0.0
  * @param {string} path - Derivation path to validate
- * @returns {boolean} True if path matches BIP-32 format (m/number'/number/...), false otherwise
+ * @returns {boolean} True if path is valid BIP-32 format, false otherwise
  * @throws {never}
  * @example
  * ```javascript
  * import * as HDWallet from './crypto/HDWallet/index.js';
  * HDWallet.isValidPath("m/44'/60'/0'/0/0"); // true
+ * HDWallet.isValidPath("m/44h/60'/0'/0/0"); // false ('h' notation not supported)
  * HDWallet.isValidPath("invalid");          // false
  * ```
  */
 export function isValidPath(path) {
-	const pathRegex = /^m(\/\d+'?)+$/;
-	return pathRegex.test(path);
+	// Must start with m/ or M/
+	if (!/^[mM]\//.test(path)) {
+		return false;
+	}
+
+	// Remove prefix and split
+	const normalized = path.slice(2);
+
+	// No trailing slash or double slashes
+	if (normalized.endsWith("/") || normalized.includes("//")) {
+		return false;
+	}
+
+	// Empty path after m/ is invalid
+	if (normalized === "") {
+		return false;
+	}
+
+	const components = normalized.split("/");
+
+	// Check depth limit
+	if (components.length > MAX_DEPTH) {
+		return false;
+	}
+
+	// Validate each component
+	for (const component of components) {
+		// Must match: digits followed by optional apostrophe
+		// Note: 'h' notation is NOT supported by @scure/bip32
+		if (!/^\d+'?$/.test(component)) {
+			return false;
+		}
+
+		const isHardened = component.endsWith("'");
+		const indexStr = isHardened ? component.slice(0, -1) : component;
+		const index = Number.parseInt(indexStr, 10);
+
+		// Check for NaN (shouldn't happen with regex, but be safe)
+		if (Number.isNaN(index)) {
+			return false;
+		}
+
+		// Non-hardened indices must be < 2^31
+		// Hardened indices must also be < 2^31 (before adding offset)
+		if (index > MAX_NORMAL_INDEX) {
+			return false;
+		}
+	}
+
+	return true;
 }


### PR DESCRIPTION
## Summary
- Fixes #125
- Added index overflow validation (< 2^31)
- Added BIP-32 max depth check (255 levels)
- Reject 'h' notation (only apostrophe supported)
- Reject double slashes, trailing slashes, decimals, hex

## Test plan
- [x] Index overflow tests
- [x] Max depth validation
- [x] 'h' notation rejection
- [x] Invalid format rejection

🤖 Generated with [Claude Code](https://claude.ai/code)