### PR TITLE
🐛 fix: Bytes.trimLeft preserves at least one byte for all-zero arrays

### DIFF
--- a/src/primitives/Bytes/Bytes.zig
+++ b/src/primitives/Bytes/Bytes.zig
@@ -494,18 +494,25 @@ test "padRight - basic" {
 }
 
 /// Trim leading zeros (no allocation, returns slice)
+/// Preserves at least one byte for all-zero arrays (represents zero value)
 pub fn trimLeft(bytes: []const u8) []const u8 {
     var start: usize = 0;
     while (start < bytes.len and bytes[start] == 0) {
         start += 1;
+    }
+    // Preserve at least one byte for all-zero arrays (represents zero value)
+    if (start == bytes.len and bytes.len > 0) {
+        return bytes[bytes.len - 1 ..];
     }
     return bytes[start..];
 }
 
 test "trimLeft - basic" {
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x12, 0x34 }, trimLeft(&[_]u8{ 0, 0, 0x12, 0x34 }));
-    try std.testing.expectEqualSlices(u8, &[_]u8{}, trimLeft(&[_]u8{ 0, 0, 0 }));
+    try std.testing.expectEqualSlices(u8, &[_]u8{0}, trimLeft(&[_]u8{ 0, 0, 0 }));
     try std.testing.expectEqualSlices(u8, &[_]u8{ 0x12, 0, 0x34 }, trimLeft(&[_]u8{ 0, 0x12, 0, 0x34 }));
+    try std.testing.expectEqualSlices(u8, &[_]u8{0}, trimLeft(&[_]u8{0}));
+    try std.testing.expectEqualSlices(u8, &[_]u8{}, trimLeft(&[_]u8{}));
 }
 
 /// Trim trailing zeros (no allocation, returns slice)

--- a/src/primitives/Bytes/trimLeft.js
+++ b/src/primitives/Bytes/trimLeft.js
@@ -1,14 +1,15 @@
 /**
- * Trim leading zeros from Bytes
+ * Trim leading zeros from Bytes, preserving at least one byte for zero values
  *
  * @param {import('./BytesType.js').BytesType} bytes - Bytes to trim
- * @returns {import('./BytesType.js').BytesType} Trimmed bytes
+ * @returns {import('./BytesType.js').BytesType} Trimmed bytes (at least 1 byte if input was non-empty)
  *
  * @example
  * ```javascript
  * import * as Bytes from './primitives/Bytes/index.js';
  * Bytes.trimLeft(new Uint8Array([0x00, 0x00, 0x12, 0x34])); // Uint8Array([0x12, 0x34])
- * Bytes.trimLeft(new Uint8Array([0x00, 0x00, 0x00]));       // Uint8Array([])
+ * Bytes.trimLeft(new Uint8Array([0x00, 0x00, 0x00]));       // Uint8Array([0x00])
+ * Bytes.trimLeft(new Uint8Array([]));                       // Uint8Array([])
  * ```
  */
 export function trimLeft(bytes) {
@@ -19,6 +20,11 @@ export function trimLeft(bytes) {
 
 	if (start === 0) {
 		return bytes;
+	}
+
+	// Preserve at least one byte for all-zero arrays (represents zero value)
+	if (start === bytes.length && bytes.length > 0) {
+		return /** @type {import('./BytesType.js').BytesType} */ (bytes.slice(-1));
 	}
 
 	return /** @type {import('./BytesType.js').BytesType} */ (bytes.slice(start));

--- a/src/primitives/Bytes/trimLeft.test.ts
+++ b/src/primitives/Bytes/trimLeft.test.ts
@@ -13,8 +13,12 @@ describe("Bytes.trimLeft", () => {
 		expect(trimLeft(bytes)).toBe(bytes);
 	});
 
-	it("handles all zeros", () => {
-		expect(trimLeft(new Uint8Array([0, 0, 0]))).toEqual(new Uint8Array([]));
+	it("preserves one zero byte for all-zero arrays", () => {
+		expect(trimLeft(new Uint8Array([0, 0, 0]))).toEqual(new Uint8Array([0]));
+	});
+
+	it("preserves single zero byte", () => {
+		expect(trimLeft(new Uint8Array([0]))).toEqual(new Uint8Array([0]));
 	});
 
 	it("handles empty bytes", () => {


### PR DESCRIPTION
## Summary
- Fixes #124
- `trimLeft([0,0,0])` now returns `[0]` instead of `[]`
- Matches RLP encoding semantics (zero = single 0x00 byte)
- Fixed both TS and Zig implementations

## Test plan
- [x] All-zero arrays return single zero byte
- [x] Empty input still returns empty
- [x] Normal trimming still works

🤖 Generated with [Claude Code](https://claude.ai/code)