### PR TITLE
🎉 feat: Add known chains validation to ChainId

### DIFF
--- a/src/primitives/ChainId/constants.js
+++ b/src/primitives/ChainId/constants.js
@@ -7,3 +7,18 @@ export const OPTIMISM = 10;
 export const ARBITRUM = 42161;
 export const BASE = 8453;
 export const POLYGON = 137;
+
+/**
+ * Map of known chain IDs to their names
+ * @type {ReadonlyMap<number, string>}
+ */
+export const KNOWN_CHAINS = new Map([
+	[MAINNET, "Mainnet"],
+	[GOERLI, "Goerli"],
+	[SEPOLIA, "Sepolia"],
+	[HOLESKY, "Holesky"],
+	[OPTIMISM, "Optimism"],
+	[ARBITRUM, "Arbitrum One"],
+	[BASE, "Base"],
+	[POLYGON, "Polygon"],
+]);

--- a/src/primitives/ChainId/getChainName.js
+++ b/src/primitives/ChainId/getChainName.js
@@ -1,0 +1,20 @@
+import { KNOWN_CHAINS } from "./constants.js";
+
+/**
+ * Get the name of a known chain by ID
+ *
+ * @param {import('./ChainIdType.js').ChainIdType} chainId - Chain ID to look up
+ * @returns {string | undefined} Chain name if known, undefined otherwise
+ *
+ * @example
+ * ```typescript
+ * import * as ChainId from '@voltaire/primitives/ChainId';
+ *
+ * ChainId.getChainName(ChainId.from(1)); // "Mainnet"
+ * ChainId.getChainName(ChainId.from(10)); // "Optimism"
+ * ChainId.getChainName(ChainId.from(999999)); // undefined
+ * ```
+ */
+export function getChainName(chainId) {
+	return KNOWN_CHAINS.get(chainId);
+}

--- a/src/primitives/ChainId/getChainName.test.ts
+++ b/src/primitives/ChainId/getChainName.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { from } from "./from.js";
+import { getChainName } from "./getChainName.js";
+import {
+	ARBITRUM,
+	BASE,
+	GOERLI,
+	HOLESKY,
+	MAINNET,
+	OPTIMISM,
+	POLYGON,
+	SEPOLIA,
+} from "./constants.js";
+
+describe("ChainId.getChainName", () => {
+	describe("returns name for known chains", () => {
+		it("returns 'Mainnet' for chain ID 1", () => {
+			expect(getChainName(from(MAINNET))).toBe("Mainnet");
+		});
+
+		it("returns 'Goerli' for chain ID 5", () => {
+			expect(getChainName(from(GOERLI))).toBe("Goerli");
+		});
+
+		it("returns 'Sepolia' for chain ID 11155111", () => {
+			expect(getChainName(from(SEPOLIA))).toBe("Sepolia");
+		});
+
+		it("returns 'Holesky' for chain ID 17000", () => {
+			expect(getChainName(from(HOLESKY))).toBe("Holesky");
+		});
+
+		it("returns 'Optimism' for chain ID 10", () => {
+			expect(getChainName(from(OPTIMISM))).toBe("Optimism");
+		});
+
+		it("returns 'Arbitrum One' for chain ID 42161", () => {
+			expect(getChainName(from(ARBITRUM))).toBe("Arbitrum One");
+		});
+
+		it("returns 'Base' for chain ID 8453", () => {
+			expect(getChainName(from(BASE))).toBe("Base");
+		});
+
+		it("returns 'Polygon' for chain ID 137", () => {
+			expect(getChainName(from(POLYGON))).toBe("Polygon");
+		});
+	});
+
+	describe("returns undefined for unknown chains", () => {
+		it("returns undefined for arbitrary chain ID", () => {
+			expect(getChainName(from(999999))).toBeUndefined();
+		});
+
+		it("returns undefined for zero", () => {
+			expect(getChainName(from(0))).toBeUndefined();
+		});
+	});
+});

--- a/src/primitives/ChainId/index.ts
+++ b/src/primitives/ChainId/index.ts
@@ -7,6 +7,7 @@ export {
 	BASE,
 	GOERLI,
 	HOLESKY,
+	KNOWN_CHAINS,
 	MAINNET,
 	OPTIMISM,
 	POLYGON,
@@ -16,6 +17,8 @@ export {
 import { equals as _equals } from "./equals.js";
 // Import all functions
 import { from } from "./from.js";
+import { getChainName as _getChainName } from "./getChainName.js";
+import { isKnownChain as _isKnownChain } from "./isKnownChain.js";
 import { isMainnet as _isMainnet } from "./isMainnet.js";
 import { toNumber as _toNumber } from "./toNumber.js";
 
@@ -35,8 +38,16 @@ export function isMainnet(chainId: number): boolean {
 	return _isMainnet.call(from(chainId));
 }
 
+export function isKnownChain(chainId: number): boolean {
+	return _isKnownChain(from(chainId));
+}
+
+export function getChainName(chainId: number): string | undefined {
+	return _getChainName(from(chainId));
+}
+
 // Export internal functions (tree-shakeable)
-export { _toNumber, _equals, _isMainnet };
+export { _toNumber, _equals, _isMainnet, _isKnownChain, _getChainName };
 
 // Export as namespace (convenience)
 export const ChainId = {
@@ -44,4 +55,6 @@ export const ChainId = {
 	toNumber,
 	equals,
 	isMainnet,
+	isKnownChain,
+	getChainName,
 };

--- a/src/primitives/ChainId/isKnownChain.js
+++ b/src/primitives/ChainId/isKnownChain.js
@@ -1,0 +1,19 @@
+import { KNOWN_CHAINS } from "./constants.js";
+
+/**
+ * Check if chain ID is a known/recognized chain
+ *
+ * @param {import('./ChainIdType.js').ChainIdType} chainId - Chain ID to check
+ * @returns {boolean} True if chain ID is recognized
+ *
+ * @example
+ * ```typescript
+ * import * as ChainId from '@voltaire/primitives/ChainId';
+ *
+ * ChainId.isKnownChain(ChainId.from(1)); // true (Mainnet)
+ * ChainId.isKnownChain(ChainId.from(999999)); // false
+ * ```
+ */
+export function isKnownChain(chainId) {
+	return KNOWN_CHAINS.has(chainId);
+}

--- a/src/primitives/ChainId/isKnownChain.test.ts
+++ b/src/primitives/ChainId/isKnownChain.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { from } from "./from.js";
+import { isKnownChain } from "./isKnownChain.js";
+import {
+	ARBITRUM,
+	BASE,
+	GOERLI,
+	HOLESKY,
+	MAINNET,
+	OPTIMISM,
+	POLYGON,
+	SEPOLIA,
+} from "./constants.js";
+
+describe("ChainId.isKnownChain", () => {
+	describe("returns true for known chains", () => {
+		it("recognizes Mainnet (1)", () => {
+			expect(isKnownChain(from(MAINNET))).toBe(true);
+		});
+
+		it("recognizes Goerli (5)", () => {
+			expect(isKnownChain(from(GOERLI))).toBe(true);
+		});
+
+		it("recognizes Sepolia (11155111)", () => {
+			expect(isKnownChain(from(SEPOLIA))).toBe(true);
+		});
+
+		it("recognizes Holesky (17000)", () => {
+			expect(isKnownChain(from(HOLESKY))).toBe(true);
+		});
+
+		it("recognizes Optimism (10)", () => {
+			expect(isKnownChain(from(OPTIMISM))).toBe(true);
+		});
+
+		it("recognizes Arbitrum (42161)", () => {
+			expect(isKnownChain(from(ARBITRUM))).toBe(true);
+		});
+
+		it("recognizes Base (8453)", () => {
+			expect(isKnownChain(from(BASE))).toBe(true);
+		});
+
+		it("recognizes Polygon (137)", () => {
+			expect(isKnownChain(from(POLYGON))).toBe(true);
+		});
+	});
+
+	describe("returns false for unknown chains", () => {
+		it("rejects arbitrary chain ID", () => {
+			expect(isKnownChain(from(999999))).toBe(false);
+		});
+
+		it("rejects zero", () => {
+			expect(isKnownChain(from(0))).toBe(false);
+		});
+
+		it("rejects chain ID close to known but not exact", () => {
+			expect(isKnownChain(from(2))).toBe(false); // close to Mainnet
+			expect(isKnownChain(from(11))).toBe(false); // close to Optimism
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #113
- Added `KNOWN_CHAINS` constant map
- Added `isKnownChain(chainId)` function
- Added `getChainName(chainId)` function
- Covers major networks (Mainnet, Goerli, Sepolia, Arbitrum, Optimism, etc)

## Test plan
- [x] isKnownChain tests
- [x] getChainName tests
- [x] All major chains covered

🤖 Generated with [Claude Code](https://claude.ai/code)