### PR TITLE
🔒 security: Add Bytes.equalsConstantTime() for timing-safe comparison

### DIFF
--- a/src/primitives/Bytes/Bytes.index.ts
+++ b/src/primitives/Bytes/Bytes.index.ts
@@ -6,6 +6,7 @@ import { clone } from "./clone.js";
 import { compare } from "./compare.js";
 import { concat } from "./concat.js";
 import { equals } from "./equals.js";
+import { equalsConstantTime } from "./equalsConstantTime.js";
 import { from } from "./from.js";
 import { fromBigInt } from "./fromBigInt.js";
 import { fromHex } from "./fromHex.js";
@@ -34,6 +35,7 @@ export {
 	compare,
 	concat,
 	equals,
+	equalsConstantTime,
 	from,
 	fromBigInt,
 	fromHex,
@@ -62,6 +64,7 @@ export const BytesType = {
 	compare,
 	concat,
 	equals,
+	equalsConstantTime,
 	from,
 	fromBigInt,
 	fromHex,

--- a/src/primitives/Bytes/equals.js
+++ b/src/primitives/Bytes/equals.js
@@ -1,6 +1,14 @@
 /**
  * Check if two Bytes are equal
  *
+ * WARNING: This function is NOT constant-time. It returns early on the first
+ * byte mismatch, which can leak timing information. Do NOT use for comparing:
+ * - Cryptographic hashes
+ * - MACs or signatures
+ * - Passwords or secret tokens
+ *
+ * For security-sensitive comparisons, use `equalsConstantTime()` instead.
+ *
  * @param {import('./BytesType.js').BytesType} a - First Bytes
  * @param {import('./BytesType.js').BytesType} b - Second Bytes
  * @returns {boolean} True if equal

--- a/src/primitives/Bytes/equalsConstantTime.js
+++ b/src/primitives/Bytes/equalsConstantTime.js
@@ -1,0 +1,41 @@
+/**
+ * Constant-time comparison of two Bytes arrays.
+ *
+ * This function is resistant to timing attacks - it always takes the same
+ * amount of time regardless of where the arrays differ. Use this for
+ * security-sensitive comparisons like:
+ * - Comparing cryptographic hashes
+ * - Comparing MACs/signatures
+ * - Comparing passwords or tokens
+ *
+ * For non-security contexts where performance matters, use `equals()` instead.
+ *
+ * @param {Uint8Array} a - First Bytes array
+ * @param {Uint8Array} b - Second Bytes array
+ * @returns {boolean} True if equal
+ *
+ * @example
+ * ```typescript
+ * import { equalsConstantTime } from './primitives/Bytes/index.js';
+ *
+ * // Use for cryptographic comparisons
+ * const isValid = equalsConstantTime(computedHash, expectedHash);
+ * ```
+ */
+export function equalsConstantTime(a, b) {
+	// Length comparison is inherently timing-safe for fixed-size types.
+	// For variable-length inputs, the length itself may leak information,
+	// but this is unavoidable without padding. Document this limitation.
+	if (a.length !== b.length) {
+		return false;
+	}
+
+	// XOR all bytes and accumulate - no early exit
+	let result = 0;
+	for (let i = 0; i < a.length; i++) {
+		// biome-ignore lint: index is always valid due to length check above
+		result |= /** @type {number} */ (a[i]) ^ /** @type {number} */ (b[i]);
+	}
+
+	return result === 0;
+}

--- a/src/primitives/Bytes/equalsConstantTime.test.ts
+++ b/src/primitives/Bytes/equalsConstantTime.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { equalsConstantTime } from "./equalsConstantTime.js";
+import type { BytesType } from "./BytesType.js";
+
+describe("equalsConstantTime", () => {
+	describe("basic equality", () => {
+		it("should return true for identical arrays", () => {
+			const a = new Uint8Array([1, 2, 3, 4]) as BytesType;
+			const b = new Uint8Array([1, 2, 3, 4]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(true);
+		});
+
+		it("should return false for different arrays", () => {
+			const a = new Uint8Array([1, 2, 3, 4]) as BytesType;
+			const b = new Uint8Array([1, 2, 3, 5]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(false);
+		});
+
+		it("should return false for different lengths", () => {
+			const a = new Uint8Array([1, 2, 3]) as BytesType;
+			const b = new Uint8Array([1, 2, 3, 4]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(false);
+		});
+
+		it("should return true for empty arrays", () => {
+			const a = new Uint8Array([]) as BytesType;
+			const b = new Uint8Array([]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(true);
+		});
+	});
+
+	describe("edge cases", () => {
+		it("should handle single byte arrays", () => {
+			const a = new Uint8Array([0xff]) as BytesType;
+			const b = new Uint8Array([0xff]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(true);
+
+			const c = new Uint8Array([0x00]) as BytesType;
+			expect(equalsConstantTime(a, c)).toBe(false);
+		});
+
+		it("should handle all zeros", () => {
+			const a = new Uint8Array(32).fill(0) as BytesType;
+			const b = new Uint8Array(32).fill(0) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(true);
+		});
+
+		it("should handle all 0xff", () => {
+			const a = new Uint8Array(32).fill(0xff) as BytesType;
+			const b = new Uint8Array(32).fill(0xff) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(true);
+		});
+
+		it("should detect difference in first byte", () => {
+			const a = new Uint8Array([0, 1, 2, 3]) as BytesType;
+			const b = new Uint8Array([1, 1, 2, 3]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(false);
+		});
+
+		it("should detect difference in last byte", () => {
+			const a = new Uint8Array([1, 2, 3, 0]) as BytesType;
+			const b = new Uint8Array([1, 2, 3, 1]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(false);
+		});
+
+		it("should detect difference in middle byte", () => {
+			const a = new Uint8Array([1, 2, 3, 4]) as BytesType;
+			const b = new Uint8Array([1, 2, 0, 4]) as BytesType;
+			expect(equalsConstantTime(a, b)).toBe(false);
+		});
+	});
+
+	describe("cryptographic sizes", () => {
+		it("should handle 32-byte hashes", () => {
+			const hash1 = new Uint8Array(32).fill(0xab) as BytesType;
+			const hash2 = new Uint8Array(32).fill(0xab) as BytesType;
+			expect(equalsConstantTime(hash1, hash2)).toBe(true);
+
+			hash2[31] = 0xac;
+			expect(equalsConstantTime(hash1, hash2)).toBe(false);
+		});
+
+		it("should handle 64-byte signatures", () => {
+			const sig1 = new Uint8Array(64).fill(0xcd) as BytesType;
+			const sig2 = new Uint8Array(64).fill(0xcd) as BytesType;
+			expect(equalsConstantTime(sig1, sig2)).toBe(true);
+		});
+
+		it("should handle 20-byte addresses", () => {
+			const addr1 = new Uint8Array(20).fill(0x12) as BytesType;
+			const addr2 = new Uint8Array(20).fill(0x12) as BytesType;
+			expect(equalsConstantTime(addr1, addr2)).toBe(true);
+		});
+	});
+
+	describe("same reference", () => {
+		it("should return true when comparing same reference", () => {
+			const a = new Uint8Array([1, 2, 3]) as BytesType;
+			expect(equalsConstantTime(a, a)).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fixes #109
- Added `equalsConstantTime()` for cryptographic contexts
- Uses XOR accumulation without early exit
- Added security warning to regular `equals()` JSDoc

## Test plan
- [x] Equal arrays return true
- [x] Different arrays return false
- [x] No early exit behavior
- [x] 14 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)