### PR TITLE
✅ test: Document ECDSA recovery validates v value

### DIFF
--- a/src/crypto/Secp256k1/recoverPublicKey.test.ts
+++ b/src/crypto/Secp256k1/recoverPublicKey.test.ts
@@ -162,6 +162,59 @@ describe("Secp256k1.recoverPublicKey", () => {
 			);
 		});
 
+		// Security: invalid v values must throw to prevent wrong address derivation
+		it("should throw InvalidSignatureError for v=2", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 2, // Invalid - only 0, 1, 27, 28 allowed
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=26", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 26, // Invalid - off by one from valid 27
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=29", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 29, // Invalid - off by one from valid 28
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+		});
+
+		it("should throw InvalidSignatureError for v=255", () => {
+			const message = Hash(sha256(new TextEncoder().encode("test")));
+			const invalidSig = {
+				r: new Uint8Array(32).fill(1),
+				s: new Uint8Array(32).fill(1),
+				v: 255, // Invalid max u8
+			};
+
+			expect(() => recoverPublicKey(invalidSig, message)).toThrow(
+				InvalidSignatureError,
+			);
+		});
+
 		it("should throw InvalidSignatureError for all-zero r", () => {
 			const message = Hash(sha256(new TextEncoder().encode("test")));
 			const invalidSig = {

--- a/src/crypto/Secp256k1/recoverPublicKeyFromHash.test.ts
+++ b/src/crypto/Secp256k1/recoverPublicKeyFromHash.test.ts
@@ -62,6 +62,77 @@ describe("Secp256k1.recoverPublicKeyFromHash", () => {
 		).toThrow("Invalid v value: 30");
 	});
 
+	// Security: invalid v values must throw to prevent wrong address derivation
+	it("should throw on v=2", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 2 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 2");
+	});
+
+	it("should throw on v=26", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 26 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 26");
+	});
+
+	it("should throw on v=29", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 29 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 29");
+	});
+
+	it("should throw on negative v", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: -1 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: -1");
+	});
+
+	it("should throw on v=255", () => {
+		const hash = Hash.keccak256String("Test");
+		const privateKey = PrivateKey.from(
+			"0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318",
+		);
+
+		const signature = Secp256k1.signHash(hash, privateKey);
+		const invalidSignature = { ...signature, v: 255 };
+
+		expect(() =>
+			Secp256k1.recoverPublicKeyFromHash(invalidSignature, hash),
+		).toThrow("Invalid v value: 255");
+	});
+
 	it("should handle v values 0 and 1", () => {
 		const hash = Hash.keccak256String("Test");
 		const privateKey = PrivateKey.from(


### PR DESCRIPTION
## Summary
- Fixes #97
- Verified v validation already exists (0, 1, 27, 28 only)
- Added 9 edge case tests for invalid v values

## Test plan
- [x] v=2 throws
- [x] v=26 throws
- [x] v=29 throws
- [x] v=255 throws
- [x] Valid v values work

🤖 Generated with [Claude Code](https://claude.ai/code)