### PR TITLE
🐛 fix: Validate size parameter in Hex.padLeft/padRight

### DIFF
--- a/src/primitives/Hex/errors.js
+++ b/src/primitives/Hex/errors.js
@@ -212,6 +212,34 @@ export class NonIntegerError extends BaseInvalidRangeError {
 	}
 }
 
+/**
+ * Error for invalid size parameter
+ * @extends {BaseInvalidRangeError}
+ */
+export class InvalidSizeError extends BaseInvalidRangeError {
+	/**
+	 * @param {string} [message]
+	 * @param {Object} [options]
+	 * @param {string} [options.code]
+	 * @param {unknown} [options.value]
+	 * @param {string} [options.expected]
+	 * @param {Record<string, unknown>} [options.context]
+	 * @param {string} [options.docsPath]
+	 * @param {Error} [options.cause]
+	 */
+	constructor(message = "Invalid size parameter", options = {}) {
+		super(message, {
+			code: options.code || "HEX_INVALID_SIZE",
+			value: options.value,
+			expected: options.expected || "non-negative integer",
+			context: options.context,
+			docsPath: options.docsPath || "/primitives/hex#error-handling",
+			cause: options.cause,
+		});
+		this.name = "InvalidSizeError";
+	}
+}
+
 // Re-export for backward compatibility
 export const InvalidHexFormatError = InvalidFormatError;
 export const InvalidHexCharacterError = InvalidCharacterError;

--- a/src/primitives/Hex/errors.ts
+++ b/src/primitives/Hex/errors.ts
@@ -184,6 +184,23 @@ export class NonIntegerError extends BaseInvalidRangeError {
 	}
 }
 
+/**
+ * Error for invalid size parameter
+ */
+export class InvalidSizeError extends BaseInvalidRangeError {
+	constructor(message = "Invalid size parameter", options: ErrorOptions = {}) {
+		super(message, {
+			code: options.code || "HEX_INVALID_SIZE",
+			value: options.value,
+			expected: options.expected || "non-negative integer",
+			context: options.context,
+			docsPath: options.docsPath || "/primitives/hex#error-handling",
+			cause: options.cause,
+		});
+		this.name = "InvalidSizeError";
+	}
+}
+
 // Re-export for backward compatibility
 export const InvalidHexFormatError = InvalidFormatError;
 export const InvalidHexCharacterError = InvalidCharacterError;

--- a/src/primitives/Hex/pad.js
+++ b/src/primitives/Hex/pad.js
@@ -1,4 +1,4 @@
-import { SizeExceededError } from "./errors.js";
+import { InvalidSizeError, SizeExceededError } from "./errors.js";
 import { fromBytes } from "./fromBytes.js";
 import { toBytes } from "./toBytes.js";
 
@@ -8,8 +8,9 @@ import { toBytes } from "./toBytes.js";
  * @see https://voltaire.tevm.sh/primitives/hex for Hex documentation
  * @since 0.0.0
  * @param {string} hex - Hex string to pad
- * @param {number} targetSize - Target size in bytes
+ * @param {number} targetSize - Target size in bytes (must be non-negative integer)
  * @returns {string} Padded hex string
+ * @throws {InvalidSizeError} If targetSize is not a non-negative integer
  * @throws {SizeExceededError} If hex exceeds target size
  * @example
  * ```javascript
@@ -17,9 +18,21 @@ import { toBytes } from "./toBytes.js";
  * const hex = Hex.from('0x1234');
  * const padded = Hex.pad(hex, 4); // '0x00001234'
  * Hex.pad('0x1234', 1); // throws SizeExceededError (2 bytes > 1 byte target)
+ * Hex.pad('0x1234', -1); // throws InvalidSizeError
+ * Hex.pad('0x1234', 1.5); // throws InvalidSizeError
  * ```
  */
 export function pad(hex, targetSize) {
+	if (!Number.isInteger(targetSize) || targetSize < 0) {
+		throw new InvalidSizeError(
+			`Invalid target size: ${targetSize}. Size must be a non-negative integer.`,
+			{
+				value: targetSize,
+				expected: "non-negative integer",
+				context: { targetSize },
+			},
+		);
+	}
 	const bytes = toBytes(/** @type {import('./HexType.js').HexType} */ (hex));
 	if (bytes.length > targetSize) {
 		throw new SizeExceededError(

--- a/src/primitives/Hex/pad.test.ts
+++ b/src/primitives/Hex/pad.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InvalidSizeError } from "./errors.js";
 import type { HexType } from "./HexType.js";
 import { pad } from "./pad.js";
 
@@ -70,5 +71,46 @@ describe("pad", () => {
 		expect(padded.length).toBe(2 + 100 * 2);
 		expect(padded.startsWith("0x00000000")).toBe(true);
 		expect(padded.endsWith("12")).toBe(true);
+	});
+
+	describe("size parameter validation", () => {
+		it("throws InvalidSizeError for negative size", () => {
+			const hex = "0x1234" as HexType;
+			expect(() => pad(hex, -1)).toThrow(InvalidSizeError);
+			expect(() => pad(hex, -1)).toThrow(/Invalid target size: -1/);
+		});
+
+		it("throws InvalidSizeError for non-integer size", () => {
+			const hex = "0x1234" as HexType;
+			expect(() => pad(hex, 1.5)).toThrow(InvalidSizeError);
+			expect(() => pad(hex, 2.7)).toThrow(/Invalid target size: 2.7/);
+		});
+
+		it("throws InvalidSizeError for NaN", () => {
+			const hex = "0x1234" as HexType;
+			expect(() => pad(hex, NaN)).toThrow(InvalidSizeError);
+			expect(() => pad(hex, NaN)).toThrow(/Invalid target size: NaN/);
+		});
+
+		it("throws InvalidSizeError for Infinity", () => {
+			const hex = "0x1234" as HexType;
+			expect(() => pad(hex, Infinity)).toThrow(InvalidSizeError);
+			expect(() => pad(hex, -Infinity)).toThrow(InvalidSizeError);
+		});
+
+		it("accepts zero as valid size", () => {
+			const hex = "0x" as HexType;
+			expect(pad(hex, 0)).toBe("0x");
+		});
+
+		it("error includes context with targetSize", () => {
+			const hex = "0x1234" as HexType;
+			try {
+				pad(hex, -5);
+			} catch (e) {
+				expect(e).toBeInstanceOf(InvalidSizeError);
+				expect((e as InvalidSizeError).context).toEqual({ targetSize: -5 });
+			}
+		});
 	});
 });

--- a/src/primitives/Hex/padRight.js
+++ b/src/primitives/Hex/padRight.js
@@ -1,3 +1,4 @@
+import { InvalidSizeError } from "./errors.js";
 import { fromBytes } from "./fromBytes.js";
 import { toBytes } from "./toBytes.js";
 
@@ -7,17 +8,29 @@ import { toBytes } from "./toBytes.js";
  * @see https://voltaire.tevm.sh/primitives/hex for Hex documentation
  * @since 0.0.0
  * @param {string} hex - Hex string to pad
- * @param {number} targetSize - Target size in bytes
+ * @param {number} targetSize - Target size in bytes (must be non-negative integer)
  * @returns {string} Right-padded hex string
- * @throws {never}
+ * @throws {InvalidSizeError} If targetSize is not a non-negative integer
  * @example
  * ```javascript
  * import * as Hex from './primitives/Hex/index.js';
  * const hex = Hex.from('0x1234');
  * const padded = Hex.padRight(hex, 4); // '0x12340000'
+ * Hex.padRight('0x1234', -1); // throws InvalidSizeError
+ * Hex.padRight('0x1234', 1.5); // throws InvalidSizeError
  * ```
  */
 export function padRight(hex, targetSize) {
+	if (!Number.isInteger(targetSize) || targetSize < 0) {
+		throw new InvalidSizeError(
+			`Invalid target size: ${targetSize}. Size must be a non-negative integer.`,
+			{
+				value: targetSize,
+				expected: "non-negative integer",
+				context: { targetSize },
+			},
+		);
+	}
 	// Normalize odd-length hex by padding with trailing 0
 	let normalized = hex;
 	if (hex.length % 2 !== 0) {

--- a/src/primitives/Hex/padRight.test.js
+++ b/src/primitives/Hex/padRight.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { InvalidSizeError } from "./errors.js";
 import { padRight } from "./padRight.js";
 
 describe("Hex.padRight", () => {
@@ -209,6 +210,49 @@ describe("Hex.padRight", () => {
 		it("accepts any hex string", () => {
 			const padded = padRight("0xabc", 4);
 			expect(padded).toBe("0xabc00000");
+		});
+	});
+
+	describe("size parameter validation", () => {
+		it("throws InvalidSizeError for negative size", () => {
+			const hex = "0x1234";
+			expect(() => padRight(hex, -1)).toThrow(InvalidSizeError);
+			expect(() => padRight(hex, -1)).toThrow(/Invalid target size: -1/);
+		});
+
+		it("throws InvalidSizeError for non-integer size", () => {
+			const hex = "0x1234";
+			expect(() => padRight(hex, 1.5)).toThrow(InvalidSizeError);
+			expect(() => padRight(hex, 2.7)).toThrow(/Invalid target size: 2.7/);
+		});
+
+		it("throws InvalidSizeError for NaN", () => {
+			const hex = "0x1234";
+			expect(() => padRight(hex, NaN)).toThrow(InvalidSizeError);
+			expect(() => padRight(hex, NaN)).toThrow(/Invalid target size: NaN/);
+		});
+
+		it("throws InvalidSizeError for Infinity", () => {
+			const hex = "0x1234";
+			expect(() => padRight(hex, Infinity)).toThrow(InvalidSizeError);
+			expect(() => padRight(hex, -Infinity)).toThrow(InvalidSizeError);
+		});
+
+		it("accepts zero as valid size (returns original)", () => {
+			const hex = "0x1234";
+			expect(padRight(hex, 0)).toBe("0x1234");
+		});
+
+		it("error includes context with targetSize", () => {
+			const hex = "0x1234";
+			try {
+				padRight(hex, -5);
+			} catch (e) {
+				expect(e).toBeInstanceOf(InvalidSizeError);
+				expect(/** @type {InvalidSizeError} */ (e).context).toEqual({
+					targetSize: -5,
+				});
+			}
 		});
 	});
 });


### PR DESCRIPTION
## Summary
- Fixes #96
- Added `InvalidSizeError` for invalid size parameters
- Rejects negative, non-integer, NaN, Infinity values
- Added 12 validation tests

## Test plan
- [x] Negative size rejected
- [x] Float size rejected
- [x] NaN rejected
- [x] Infinity rejected

🤖 Generated with [Claude Code](https://claude.ai/code)