### PR TITLE
🐛 fix: Validate storage key format in AccessList.from()

### DIFF
--- a/src/primitives/AccessList/AccessList.test.ts
+++ b/src/primitives/AccessList/AccessList.test.ts
@@ -717,6 +717,35 @@ describe("AccessList.from", () => {
 		expect(result[1]?.address).toEqual(addr2);
 		expect(result[2]?.address).toEqual(addr3);
 	});
+
+	it("throws for invalid storage key length (not 32 bytes)", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: [new Uint8Array(31)] }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
+
+	it("throws for storage key that is too long", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: [new Uint8Array(33)] }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
+
+	it("throws for non-Uint8Array storage key", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: addr1, storageKeys: ["0x1234"] }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
+
+	it("throws for invalid address length", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		const list = [{ address: new Uint8Array(19), storageKeys: [] }] as any;
+		expect(() => from(list)).toThrow("Invalid access list item");
+	});
+
+	it("throws for non-array input", () => {
+		// biome-ignore lint/suspicious/noExplicitAny: test requires type flexibility
+		expect(() => from({} as any)).toThrow("Access list must be an array");
+	});
 });
 
 // ============================================================================

--- a/src/primitives/AccessList/from.js
+++ b/src/primitives/AccessList/from.js
@@ -1,3 +1,4 @@
+import { assertValid } from "./assertValid.js";
 import { fromBytes } from "./fromBytes.js";
 
 /**
@@ -7,11 +8,12 @@ import { fromBytes } from "./fromBytes.js";
  * @since 0.0.0
  * @param {readonly import('../BrandedAccessList.js').Item[] | Uint8Array} value - AccessList items or RLP bytes
  * @returns {import('../BrandedAccessList.js').BrandedAccessList} AccessList
- * @throws {never}
+ * @throws {import('../errors/index.js').InvalidFormatError} If invalid structure
+ * @throws {import('../errors/index.js').InvalidLengthError} If invalid address or storage key length
  * @example
  * ```javascript
  * import * as AccessList from './primitives/AccessList/index.js';
- * const list = AccessList.from([{ address: '0x742d35Cc...', storageKeys: [] }]);
+ * const list = AccessList.from([{ address: addr, storageKeys: [key] }]);
  * const list2 = AccessList.from(bytes); // from RLP bytes
  * ```
  */
@@ -19,5 +21,6 @@ export function from(value) {
 	if (value instanceof Uint8Array) {
 		return fromBytes(value);
 	}
+	assertValid(value);
 	return value;
 }


### PR DESCRIPTION
## Summary
- Fixes #88
- Added assertValid() call to from() for array inputs
- Rejects storage keys not exactly 32 bytes per EIP-2930
- Added 5 validation tests

## Test plan
- [x] Invalid storage key length rejected
- [x] Non-Uint8Array storage keys rejected
- [x] Invalid address length rejected
- [x] Non-array inputs rejected

🤖 Generated with [Claude Code](https://claude.ai/code)