### PR TITLE
🐛 fix: Add range validation for SSZ uint8/16/32 encoding

### DIFF
--- a/src/primitives/Ssz/Ssz.test.ts
+++ b/src/primitives/Ssz/Ssz.test.ts
@@ -158,6 +158,61 @@ describe("SSZ Basic Types", () => {
 			expect(() => Ssz.encodeBasic(42, "invalid")).toThrow("Unsupported type");
 		});
 	});
+
+	describe("range validation", () => {
+		// uint8 range: 0-255
+		it("throws on uint8 value > 255", () => {
+			expect(() => Ssz.encodeBasic(256, "uint8")).toThrow(RangeError);
+		});
+
+		it("throws on negative uint8 value", () => {
+			expect(() => Ssz.encodeBasic(-1, "uint8")).toThrow(RangeError);
+		});
+
+		it("throws on non-integer uint8 value", () => {
+			expect(() => Ssz.encodeBasic(1.5, "uint8")).toThrow(RangeError);
+		});
+
+		it("accepts max uint8 value (255)", () => {
+			expect(Ssz.encodeBasic(255, "uint8")).toEqual(new Uint8Array([255]));
+		});
+
+		// uint16 range: 0-65535
+		it("throws on uint16 value > 65535", () => {
+			expect(() => Ssz.encodeBasic(65536, "uint16")).toThrow(RangeError);
+		});
+
+		it("throws on negative uint16 value", () => {
+			expect(() => Ssz.encodeBasic(-1, "uint16")).toThrow(RangeError);
+		});
+
+		it("throws on non-integer uint16 value", () => {
+			expect(() => Ssz.encodeBasic(1.5, "uint16")).toThrow(RangeError);
+		});
+
+		it("accepts max uint16 value (65535)", () => {
+			const encoded = Ssz.encodeBasic(65535, "uint16");
+			expect(encoded).toEqual(new Uint8Array([0xff, 0xff]));
+		});
+
+		// uint32 range: 0-4294967295
+		it("throws on uint32 value > 4294967295", () => {
+			expect(() => Ssz.encodeBasic(4294967296, "uint32")).toThrow(RangeError);
+		});
+
+		it("throws on negative uint32 value", () => {
+			expect(() => Ssz.encodeBasic(-1, "uint32")).toThrow(RangeError);
+		});
+
+		it("throws on non-integer uint32 value", () => {
+			expect(() => Ssz.encodeBasic(1.5, "uint32")).toThrow(RangeError);
+		});
+
+		it("accepts max uint32 value (4294967295)", () => {
+			const encoded = Ssz.encodeBasic(4294967295, "uint32");
+			expect(encoded).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+		});
+	});
 });
 
 describe("SSZ Hash Tree Root", () => {

--- a/src/primitives/Ssz/encodeBasic.js
+++ b/src/primitives/Ssz/encodeBasic.js
@@ -1,3 +1,10 @@
+/** @type {number} */
+const UINT8_MAX = 0xff;
+/** @type {number} */
+const UINT16_MAX = 0xffff;
+/** @type {number} */
+const UINT32_MAX = 0xffffffff;
+
 /**
  * @description Encodes basic types using SSZ serialization
  * @param {number | bigint | boolean} value - Value to encode
@@ -7,20 +14,38 @@
 export function encodeBasic(value, type) {
 	switch (type) {
 		case "uint8": {
+			const n = Number(value);
+			if (n < 0 || n > UINT8_MAX || !Number.isInteger(n)) {
+				throw new RangeError(
+					`Value ${value} out of range for uint8 (0-${UINT8_MAX})`,
+				);
+			}
 			const buf = new Uint8Array(1);
-			buf[0] = Number(value);
+			buf[0] = n;
 			return buf;
 		}
 		case "uint16": {
+			const n = Number(value);
+			if (n < 0 || n > UINT16_MAX || !Number.isInteger(n)) {
+				throw new RangeError(
+					`Value ${value} out of range for uint16 (0-${UINT16_MAX})`,
+				);
+			}
 			const buf = new Uint8Array(2);
 			const view = new DataView(buf.buffer);
-			view.setUint16(0, Number(value), true); // little-endian
+			view.setUint16(0, n, true); // little-endian
 			return buf;
 		}
 		case "uint32": {
+			const n = Number(value);
+			if (n < 0 || n > UINT32_MAX || !Number.isInteger(n)) {
+				throw new RangeError(
+					`Value ${value} out of range for uint32 (0-${UINT32_MAX})`,
+				);
+			}
 			const buf = new Uint8Array(4);
 			const view = new DataView(buf.buffer);
-			view.setUint32(0, Number(value), true); // little-endian
+			view.setUint32(0, n, true); // little-endian
 			return buf;
 		}
 		case "uint64": {


### PR DESCRIPTION
## Summary
- Fixes #82
- Added range checks for uint8 (0-255), uint16 (0-65535), uint32 (0-4294967295)
- Added non-integer validation
- Throws RangeError instead of silent truncation

## Test plan
- [x] Overflow values rejected
- [x] Negative values rejected
- [x] Non-integers rejected
- [x] Max boundary values accepted

🤖 Generated with [Claude Code](https://claude.ai/code)