### PR TITLE
🐛 fix: Reject negative values in Gwei and Ether modules

### DIFF
--- a/src/primitives/Denomination/Wei.test.ts
+++ b/src/primitives/Denomination/Wei.test.ts
@@ -17,6 +17,18 @@ describe("Wei", () => {
 		expect(wei).toBe(1000n);
 	});
 
+	it("rejects negative bigint", () => {
+		expect(() => Wei(-1n)).toThrow("cannot be negative");
+	});
+
+	it("rejects negative number", () => {
+		expect(() => Wei(-1)).toThrow("cannot be negative");
+	});
+
+	it("rejects negative string", () => {
+		expect(() => Wei("-1")).toThrow("cannot be negative");
+	});
+
 	it("converts Wei to Gwei", () => {
 		const wei = Wei(1_000_000_000n);
 		const gwei = Wei.toGwei(wei);

--- a/src/primitives/Denomination/ether-from.test.ts
+++ b/src/primitives/Denomination/ether-from.test.ts
@@ -64,4 +64,26 @@ describe("from", () => {
 			expect(ether).toBe(large.toString());
 		});
 	});
+
+	describe("negative value rejection", () => {
+		it("rejects negative bigint", () => {
+			expect(() => from(-1n)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative number", () => {
+			expect(() => from(-1)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative string", () => {
+			expect(() => from("-1")).toThrow("cannot be negative");
+		});
+
+		it("rejects negative decimal number", () => {
+			expect(() => from(-1.5)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative decimal string", () => {
+			expect(() => from("-0.001")).toThrow("cannot be negative");
+		});
+	});
 });

--- a/src/primitives/Denomination/ether-from.ts
+++ b/src/primitives/Denomination/ether-from.ts
@@ -20,11 +20,17 @@ import type { EtherType as BrandedEther } from "./EtherType.js";
  */
 export function from(value: bigint | number | string): BrandedEther {
 	if (typeof value === "bigint") {
+		if (value < 0n) {
+			throw new Error(`Ether value cannot be negative: ${value}`);
+		}
 		return value.toString() as BrandedEther;
 	}
 	if (typeof value === "number") {
 		if (!Number.isFinite(value)) {
 			throw new Error(`Invalid Ether value: ${value}`);
+		}
+		if (value < 0) {
+			throw new Error(`Ether value cannot be negative: ${value}`);
 		}
 		return value.toString() as BrandedEther;
 	}
@@ -32,6 +38,9 @@ export function from(value: bigint | number | string): BrandedEther {
 	const trimmed = value.trim();
 	if (trimmed === "" || Number.isNaN(Number(trimmed))) {
 		throw new Error(`Invalid Ether value: ${value}`);
+	}
+	if (Number(trimmed) < 0) {
+		throw new Error(`Ether value cannot be negative: ${value}`);
 	}
 	return trimmed as BrandedEther;
 }

--- a/src/primitives/Denomination/gwei-from.test.ts
+++ b/src/primitives/Denomination/gwei-from.test.ts
@@ -64,4 +64,26 @@ describe("from", () => {
 			expect(gwei).toBe(large.toString());
 		});
 	});
+
+	describe("negative value rejection", () => {
+		it("rejects negative bigint", () => {
+			expect(() => from(-1n)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative number", () => {
+			expect(() => from(-1)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative string", () => {
+			expect(() => from("-1")).toThrow("cannot be negative");
+		});
+
+		it("rejects negative decimal number", () => {
+			expect(() => from(-1.5)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative decimal string", () => {
+			expect(() => from("-0.001")).toThrow("cannot be negative");
+		});
+	});
 });

--- a/src/primitives/Denomination/gwei-from.ts
+++ b/src/primitives/Denomination/gwei-from.ts
@@ -20,11 +20,17 @@ import type { GweiType as BrandedGwei } from "./GweiType.js";
  */
 export function from(value: bigint | number | string): BrandedGwei {
 	if (typeof value === "bigint") {
+		if (value < 0n) {
+			throw new Error(`Gwei value cannot be negative: ${value}`);
+		}
 		return value.toString() as BrandedGwei;
 	}
 	if (typeof value === "number") {
 		if (!Number.isFinite(value)) {
 			throw new Error(`Invalid Gwei value: ${value}`);
+		}
+		if (value < 0) {
+			throw new Error(`Gwei value cannot be negative: ${value}`);
 		}
 		return value.toString() as BrandedGwei;
 	}
@@ -32,6 +38,9 @@ export function from(value: bigint | number | string): BrandedGwei {
 	const trimmed = value.trim();
 	if (trimmed === "" || Number.isNaN(Number(trimmed))) {
 		throw new Error(`Invalid Gwei value: ${value}`);
+	}
+	if (Number(trimmed) < 0) {
+		throw new Error(`Gwei value cannot be negative: ${value}`);
 	}
 	return trimmed as BrandedGwei;
 }

--- a/src/primitives/Denomination/wei-from.test.ts
+++ b/src/primitives/Denomination/wei-from.test.ts
@@ -64,4 +64,22 @@ describe("from", () => {
 			expect(wei).toBe(large);
 		});
 	});
+
+	describe("negative value rejection", () => {
+		it("rejects negative bigint", () => {
+			expect(() => from(-1n)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative number", () => {
+			expect(() => from(-1)).toThrow("cannot be negative");
+		});
+
+		it("rejects negative string", () => {
+			expect(() => from("-1")).toThrow("cannot be negative");
+		});
+
+		it("rejects large negative bigint", () => {
+			expect(() => from(-1000000000000000000n)).toThrow("cannot be negative");
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Fixes #80
- Added negative value validation to Gwei.from() and Ether.from()
- Wei already rejected negatives; now consistent across all denominations
- Added 17 new tests

## Test plan
- [x] Negative bigint rejected
- [x] Negative number rejected
- [x] Negative string rejected
- [x] All 175 denomination tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)