### PR TITLE
🐛 fix: Validate leading zeros in Address.fromAbiEncoded

### DIFF
--- a/src/primitives/Address/errors.js
+++ b/src/primitives/Address/errors.js
@@ -182,6 +182,41 @@ export class InvalidAddressError extends ValidationError {
 }
 
 /**
+ * Error thrown when ABI-encoded address has non-zero padding bytes
+ *
+ * @throws {InvalidAbiEncodedPaddingError}
+ */
+export class InvalidAbiEncodedPaddingError extends ValidationError {
+	/**
+	 * @param {string} [message] - Error message
+	 * @param {object} [options] - Error options
+	 * @param {string} [options.code] - Error code
+	 * @param {unknown} [options.value] - Invalid value
+	 * @param {string} [options.expected] - Expected format
+	 * @param {Record<string, unknown>} [options.context] - Additional context
+	 * @param {string} [options.docsPath] - Documentation path
+	 * @param {Error} [options.cause] - Root cause error
+	 */
+	constructor(message, options) {
+		super(
+			message ||
+				"ABI-encoded address has non-zero padding in first 12 bytes",
+			{
+				code: options?.code || "INVALID_ABI_ENCODED_PADDING",
+				value: options?.value,
+				expected: options?.expected || "First 12 bytes must be zero",
+				context: options?.context,
+				docsPath:
+					options?.docsPath ||
+					"/primitives/address/from-abi-encoded#error-handling",
+				cause: options?.cause,
+			},
+		);
+		this.name = "InvalidAbiEncodedPaddingError";
+	}
+}
+
+/**
  * Error thrown when address checksum is invalid
  *
  * @throws {InvalidChecksumError}

--- a/src/primitives/Address/fromAbiEncoded.test.ts
+++ b/src/primitives/Address/fromAbiEncoded.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Address } from "../index.js";
+import { InvalidAbiEncodedPaddingError } from "./errors.js";
 import { fromAbiEncoded } from "./fromAbiEncoded.js";
 
 describe("fromAbiEncoded", () => {
@@ -16,7 +17,19 @@ describe("fromAbiEncoded", () => {
 		expect(addr[19]).toBe(20);
 	});
 
-	it("ignores first 12 padding bytes", () => {
+	it("accepts zero padding in first 12 bytes", () => {
+		const encoded = new Uint8Array(32);
+		// First 12 bytes are already zeros (default)
+		// Set address bytes
+		for (let i = 12; i < 32; i++) {
+			encoded[i] = i - 11;
+		}
+		const addr = fromAbiEncoded(encoded);
+		expect(addr.length).toBe(20);
+		expect(addr[0]).toBe(1);
+	});
+
+	it("throws on non-zero padding in first 12 bytes", () => {
 		const encoded = new Uint8Array(32);
 		// Fill padding with non-zero values
 		for (let i = 0; i < 12; i++) {
@@ -26,8 +39,34 @@ describe("fromAbiEncoded", () => {
 		for (let i = 12; i < 32; i++) {
 			encoded[i] = 0;
 		}
-		const addr = fromAbiEncoded(encoded);
-		expect(addr.every((b) => b === 0)).toBe(true);
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			InvalidAbiEncodedPaddingError,
+		);
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			"non-zero byte at position 0",
+		);
+	});
+
+	it("throws on single non-zero padding byte", () => {
+		const encoded = new Uint8Array(32);
+		encoded[5] = 0x01; // Single non-zero byte in padding
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			InvalidAbiEncodedPaddingError,
+		);
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			"non-zero byte at position 5: 0x01",
+		);
+	});
+
+	it("throws on non-zero byte at position 11 (last padding byte)", () => {
+		const encoded = new Uint8Array(32);
+		encoded[11] = 0xab;
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			InvalidAbiEncodedPaddingError,
+		);
+		expect(() => fromAbiEncoded(encoded)).toThrow(
+			"non-zero byte at position 11: 0xab",
+		);
 	});
 
 	it("extracts address from known ABI encoding", () => {
@@ -78,5 +117,19 @@ describe("fromAbiEncoded", () => {
 		const encoded = Address.toAbiEncoded(original);
 		const decoded = fromAbiEncoded(encoded);
 		expect(Address.equals(decoded, original)).toBe(true);
+	});
+
+	it("error includes helpful context", () => {
+		const encoded = new Uint8Array(32);
+		encoded[3] = 0xde;
+		try {
+			fromAbiEncoded(encoded);
+			expect.fail("Should have thrown");
+		} catch (e) {
+			expect(e).toBeInstanceOf(InvalidAbiEncodedPaddingError);
+			const err = e as InvalidAbiEncodedPaddingError;
+			expect(err.context?.position).toBe(3);
+			expect(err.context?.byte).toBe(0xde);
+		}
 	});
 });


### PR DESCRIPTION
## Summary
- Fixes #75
- Added validation that first 12 bytes are zeros per ABI spec
- Added `InvalidAbiEncodedPaddingError` with detailed context
- Updated tests

## Test plan
- [x] Valid zero padding accepted
- [x] Non-zero padding rejected
- [x] Error includes position and byte value

🤖 Generated with [Claude Code](https://claude.ai/code)