### PR TITLE
🐛 fix: Remove dead code in Uint64.toNumber

### DIFF
--- a/src/primitives/Uint64/toNumber.js
+++ b/src/primitives/Uint64/toNumber.js
@@ -16,6 +16,9 @@
  */
 export function toNumber(uint) {
 	if (uint > BigInt(Number.MAX_SAFE_INTEGER)) {
+		console.warn(
+			`Uint64.toNumber: Value ${uint} exceeds MAX_SAFE_INTEGER and may lose precision`,
+		);
 	}
 	return Number(uint);
 }

--- a/src/primitives/Uint64/toNumber.test.ts
+++ b/src/primitives/Uint64/toNumber.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ONE, ZERO } from "./constants.js";
 import { from } from "./from.js";
 import { toNumber } from "./toNumber.js";
@@ -29,9 +29,14 @@ describe("Uint64.toNumber", () => {
 
 	describe("unsafe conversions", () => {
 		it("logs warning on value exceeding Number.MAX_SAFE_INTEGER", () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 			const unsafe = from(BigInt(Number.MAX_SAFE_INTEGER) + 1n);
 			const result = toNumber(unsafe);
 			expect(typeof result).toBe("number");
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.stringContaining("exceeds MAX_SAFE_INTEGER"),
+			);
+			warnSpy.mockRestore();
 		});
 
 		it("converts MAX with precision loss", () => {


### PR DESCRIPTION
## Summary
- Fixes #74
- Fixed empty if-block by adding precision loss warning
- Added test to verify warning is logged

## Test plan
- [x] Warning logged for values > MAX_SAFE_INTEGER
- [x] Normal values work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)