### PR TITLE
🐛 fix: BlockHash.fromBytes returns copy instead of reference

### DIFF
--- a/src/primitives/BlockHash/BlockHash.test.ts
+++ b/src/primitives/BlockHash/BlockHash.test.ts
@@ -116,6 +116,24 @@ describe("BlockHash", () => {
 			const hash = BlockHash.fromBytes(testBytes);
 			expect(hash).toHaveLength(32);
 		});
+
+		it("returns a copy, not a reference to the input", () => {
+			const input = new Uint8Array(32);
+			input[0] = 0xaa;
+			const hash = BlockHash.fromBytes(input);
+
+			// Verify initial value
+			expect(hash[0]).toBe(0xaa);
+
+			// Mutate the original input
+			input[0] = 0xbb;
+
+			// BlockHash should not be affected by mutation of input
+			expect(hash[0]).toBe(0xaa);
+
+			// Verify they are different array instances
+			expect(hash).not.toBe(input);
+		});
 	});
 
 	describe("toHex", () => {

--- a/src/primitives/BlockHash/fromBytes.js
+++ b/src/primitives/BlockHash/fromBytes.js
@@ -1,14 +1,17 @@
 import { InvalidBlockHashLengthError } from "./errors.js";
 
+/** @constant {number} */
+const SIZE = 32;
+
 /**
- * Create BlockHash from bytes
+ * Create BlockHash from bytes. Returns a copy of the input.
  *
- * @param {Uint8Array} bytes
- * @returns {import('./BlockHashType.js').BlockHashType}
- * @throws {InvalidBlockHashLengthError}
+ * @param {Uint8Array} bytes - Input bytes (must be 32 bytes)
+ * @returns {import('./BlockHashType.js').BlockHashType} BlockHash copy
+ * @throws {InvalidBlockHashLengthError} If bytes length is not 32
  */
 export function fromBytes(bytes) {
-	if (bytes.length !== 32) {
+	if (bytes.length !== SIZE) {
 		throw new InvalidBlockHashLengthError(
 			`BlockHash must be 32 bytes, got ${bytes.length}`,
 			{
@@ -18,5 +21,7 @@ export function fromBytes(bytes) {
 			},
 		);
 	}
-	return /** @type {import('./BlockHashType.js').BlockHashType} */ (bytes);
+	const result = new Uint8Array(SIZE);
+	result.set(bytes);
+	return /** @type {import('./BlockHashType.js').BlockHashType} */ (result);
 }


### PR DESCRIPTION
## Summary
- Fixes #73
- Changed fromBytes to return a copy instead of reference
- Prevents caller mutation from affecting BlockHash

## Test plan
- [x] Input mutation doesn't affect BlockHash
- [x] Normal usage works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)