### PR TITLE
fix(primitives): remove duplicate root exports

### DIFF
--- a/packages/voltaire-zig/src/primitives/root.zig
+++ b/packages/voltaire-zig/src/primitives/root.zig
@@ -117,8 +117,6 @@ pub const ChainId = @import("ChainId/ChainId.zig");
 pub const Epoch = @import("Epoch/Epoch.zig");
 pub const Hash = @import("Hash/Hash.zig");
 pub const Journal = @import("Journal/Journal.zig");
-pub const LightClientHeader = @import("LightClientHeader/LightClientHeader.zig");
-pub const LightClientUpdate = @import("LightClientUpdate/LightClientUpdate.zig");
 pub const LogIndex = @import("LogIndex/LogIndex.zig");
 pub const Nonce = @import("Nonce/Nonce.zig");
 pub const PrivateKey = @import("PrivateKey/PrivateKey.zig");
@@ -127,8 +125,6 @@ pub const Signature = @import("Signature/Signature.zig").Signature;
 pub const Slot = @import("Slot/Slot.zig");
 pub const StateRoot = @import("StateRoot/StateRoot.zig");
 pub const StorageValue = @import("StorageValue/StorageValue.zig");
-pub const SyncCommittee = @import("SyncCommittee/SyncCommittee.zig");
-pub const SyncAggregate = @import("SyncAggregate/SyncAggregate.zig");
 pub const TransactionHash = @import("TransactionHash/TransactionHash.zig");
 
 // Filter types
@@ -159,7 +155,6 @@ pub const Abi = @import("Abi/Abi.zig");
 pub const AbiEncoding = @import("Abi/abi_encoding.zig");
 pub const Base64 = @import("base64.zig");
 pub const Ssz = @import("Ssz/root.zig");
-pub const consensus = @import("consensus/consensus.zig");
 
 // Utilities
 pub const Numeric = @import("Uint/numeric.zig");
@@ -274,8 +269,6 @@ pub const Hardfork = @import("Hardfork/hardfork.zig").Hardfork;
 pub const ForkTransition = @import("Hardfork/hardfork.zig").ForkTransition;
 pub const Eips = @import("Hardfork/Eips.zig").Eips;
 pub const EipOverride = @import("Hardfork/Eips.zig").EipOverride;
-pub const ConsensusSpec = @import("ConsensusSpec/ConsensusSpec.zig");
-pub const ForkConfig = @import("ForkConfig/ForkConfig.zig");
 
 // Network primitives
 pub const NetworkId = @import("NetworkId/NetworkId.zig");


### PR DESCRIPTION
## Summary
- remove duplicate light-client and consensus re-exports from `packages/voltaire-zig/src/primitives/root.zig`
- preserve the intended light-client exports in the dedicated section only
- unblock the Zig build from failing on duplicate struct member names

## Validation
- `zig build`
- `zig build test` now progresses past the duplicate-export failure and reaches the next unrelated blockchain test error