### PR TITLE
test: exclude declaration files from coverage

### DIFF
--- a/packages/voltaire-ts/vitest.config.ts
+++ b/packages/voltaire-ts/vitest.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
 		coverage: {
 			reportOnFailure: true,
 			include: ["src/**/*.ts"],
-			exclude: ["src/**/*.test.ts", "src/**/*.test-d.ts", "src/**/*.spec.ts"],
+			exclude: ["src/**/*.d.ts", "src/**/*.test.ts", "src/**/*.test-d.ts", "src/**/*.spec.ts"],
 			provider: "v8",
 			reporter: ["text", "json-summary", "json"],
 			thresholds: {


### PR DESCRIPTION
## Summary
- exclude TypeScript declaration files from V8 coverage collection
- keep declaration files from being treated as executable sources during coverage remapping
- leave the existing test/source coverage patterns unchanged for real runtime files

## Validation
- pnpm --filter @tevm/voltaire exec vitest run --coverage src/primitives/Hash/Hash.wasm.test.ts src/primitives/Rlp/Rlp.wasm.test.ts src/primitives/Hex/Hex.wasm.test.ts src/primitives/Uint/Uint256.wasm.test.ts src/primitives/Address/Address.wasm.test.ts src/wasm-loader/loader.test.ts src/wasm-loader/loader.additional.test.ts src/wasm/fork-provider.wasm.test.ts src/crypto/sha256.test.ts
  - all targeted WASM suites pass
  - declaration-file coverage parse errors are gone
